### PR TITLE
get anime title by AnitomySharp

### DIFF
--- a/Jellyfin.Plugin.Bangumi.Test/Episode.cs
+++ b/Jellyfin.Plugin.Bangumi.Test/Episode.cs
@@ -265,4 +265,21 @@ public class Episode
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
         return episodeData.Item.IndexNumber;
     }
+
+    [TestMethod]
+    public async Task GetEpisodeByAnitomySharp()
+    {
+        _plugin.Configuration.AlwaysGetEpisodeByAnitomySharp = true;
+        var episodeData = await _provider.GetMetadata(new EpisodeInfo
+        {
+            IndexNumber = 0,
+            Path = FakePath.CreateFile("[VCB-Studio] BEATLESS [Ma10p_1080p]/[VCB-Studio] BEATLESS [05][Ma10p_1080p][x265_flac].mkv"),
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "227102" } }
+        }, _token);
+        _plugin.Configuration.AlwaysGetEpisodeByAnitomySharp = false;
+        Assert.IsNotNull(episodeData, "episode data should not be null");
+        Assert.IsNotNull(episodeData.Item, "episode data should not be null");
+        Assert.AreEqual(5, episodeData.Item.IndexNumber, "should fix episode index automatically");
+        Assert.AreEqual("Tools for outsoucers", episodeData.Item.Name, "should return the right episode title");
+    }
 }

--- a/Jellyfin.Plugin.Bangumi.Test/Movie.cs
+++ b/Jellyfin.Plugin.Bangumi.Test/Movie.cs
@@ -59,13 +59,13 @@ public class Movie
     [TestMethod]
     public async Task GetNameByAnitomySharp()
     {
-        _plugin.Configuration.AlwaysUseAnitomySharp = true;
+        _plugin.Configuration.AlwaysGetTitleByAnitomySharp = true;
         var result = await _provider.GetMetadata(new MovieInfo
         {
             Name = "[Zagzad] Memories (BDRip 1764x972 1800x976 1788x932 HEVC-10bit THD)",
             Path = FakePath.Create("[Zagzad] Memories (BDRip 1764x972 1800x976 1788x932 HEVC-10bit THD)")
         }, _token);  
-        _plugin.Configuration.AlwaysUseAnitomySharp = false;
+        _plugin.Configuration.AlwaysGetTitleByAnitomySharp = false;
         Assert.AreEqual("回忆三部曲", result.Item.Name, "should return correct series name");
     }
 

--- a/Jellyfin.Plugin.Bangumi.Test/Movie.cs
+++ b/Jellyfin.Plugin.Bangumi.Test/Movie.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Bangumi.Providers;
+using Jellyfin.Plugin.Bangumi.Test.Util;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -14,6 +15,7 @@ namespace Jellyfin.Plugin.Bangumi.Test;
 public class Movie
 {
     private readonly MovieProvider _provider = ServiceLocator.GetService<MovieProvider>();
+    private readonly Bangumi.Plugin _plugin = ServiceLocator.GetService<Bangumi.Plugin>();
 
     private readonly CancellationToken _token = new();
 
@@ -52,6 +54,19 @@ public class Movie
             Name = "STEINS;GATE 負荷領域のデジャヴ"
         }, _token);
         Assert.IsTrue(searchResults.Any(x => x.ProviderIds[Constants.ProviderName].Equals("23119")), "should have correct search result");
+    }
+
+    [TestMethod]
+    public async Task GetNameByAnitomySharp()
+    {
+        _plugin.Configuration.AlwaysUseAnitomySharp = true;
+        var result = await _provider.GetMetadata(new MovieInfo
+        {
+            Name = "[Zagzad] Memories (BDRip 1764x972 1800x976 1788x932 HEVC-10bit THD)",
+            Path = FakePath.Create("[Zagzad] Memories (BDRip 1764x972 1800x976 1788x932 HEVC-10bit THD)")
+        }, _token);  
+        _plugin.Configuration.AlwaysUseAnitomySharp = false;
+        Assert.AreEqual("回忆三部曲", result.Item.Name, "should return correct series name");
     }
 
     [TestMethod]

--- a/Jellyfin.Plugin.Bangumi.Test/Series.cs
+++ b/Jellyfin.Plugin.Bangumi.Test/Series.cs
@@ -65,13 +65,13 @@ public class Series
     [TestMethod]
     public async Task GetNameByAnitomySharp()
     {
-        _plugin.Configuration.AlwaysUseAnitomySharp = true;
+        _plugin.Configuration.AlwaysGetTitleByAnitomySharp = true;
         var result = await _provider.GetMetadata(new SeriesInfo
         {
             Name = "[Airota&LoliHouse] Toaru Kagaku no Railgun T [BDRip 1080p HEVC-10bit FLAC]",
             Path = FakePath.Create("[Airota&LoliHouse] Toaru Kagaku no Railgun T [BDRip 1080p HEVC-10bit FLAC]")
         }, _token);        
-        _plugin.Configuration.AlwaysUseAnitomySharp = false;
+        _plugin.Configuration.AlwaysGetTitleByAnitomySharp = false;
         Assert.AreEqual("とある科学の超電磁砲T", result.Item.Name, "should return correct series name");
     }
 

--- a/Jellyfin.Plugin.Bangumi.Test/Series.cs
+++ b/Jellyfin.Plugin.Bangumi.Test/Series.cs
@@ -17,6 +17,7 @@ public class Series
     private readonly BangumiApi _api = ServiceLocator.GetService<BangumiApi>();
     private readonly SubjectImageProvider _imageProvider = ServiceLocator.GetService<SubjectImageProvider>();
     private readonly SeriesProvider _provider = ServiceLocator.GetService<SeriesProvider>();
+    private readonly Bangumi.Plugin _plugin = ServiceLocator.GetService<Bangumi.Plugin>();
 
     private readonly CancellationToken _token = new();
 
@@ -59,6 +60,19 @@ public class Series
             Path = FakePath.Create("White Album 2")
         }, _token);
         Assert.IsTrue(searchResults.Any(x => x.ProviderIds[Constants.ProviderName].Equals("69496")), "should have correct search result");
+    }
+
+    [TestMethod]
+    public async Task GetNameByAnitomySharp()
+    {
+        _plugin.Configuration.AlwaysUseAnitomySharp = true;
+        var result = await _provider.GetMetadata(new SeriesInfo
+        {
+            Name = "[Airota&LoliHouse] Toaru Kagaku no Railgun T [BDRip 1080p HEVC-10bit FLAC]",
+            Path = FakePath.Create("[Airota&LoliHouse] Toaru Kagaku no Railgun T [BDRip 1080p HEVC-10bit FLAC]")
+        }, _token);        
+        _plugin.Configuration.AlwaysUseAnitomySharp = false;
+        Assert.AreEqual("とある科学の超電磁砲T", result.Item.Name, "should return correct series name");
     }
 
     [TestMethod]

--- a/Jellyfin.Plugin.Bangumi/Configuration/ConfigPage.html
+++ b/Jellyfin.Plugin.Bangumi/Configuration/ConfigPage.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+﻿﻿<!DOCTYPE html>
 
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -130,6 +130,12 @@
                         <span>始终根据文件名猜测集数</span>
                     </label>
                 </div>
+                <div class="checkboxContainer checkboxContainer-withDescription">
+                    <label class="emby-checkbox-label">
+                        <input id="AlwaysUseAnitomySharp" is="emby-checkbox" type="checkbox"/>
+                        <span>始终使用AnitomySharp猜测动画名</span>
+                    </label>
+                </div>
                 <div>
                     <button class="raised button-submit block emby-button" is="emby-button" type="submit">
                         <span>保存</span>
@@ -176,6 +182,7 @@
             function loadConfiguration() {
                 return ApiClient.getPluginConfiguration(pluginId).then(function (config) {
                     container.querySelector('#AlwaysReplaceEpisodeNumber').checked = config.AlwaysReplaceEpisodeNumber;
+                    container.querySelector('#AlwaysUseAnitomySharp').checked = config.AlwaysUseAnitomySharp;
                     container.querySelector('#TranslationPreference').value = config.TranslationPreference;
                 });
             }
@@ -183,6 +190,7 @@
             function saveConfiguration() {
                 return wrapLoading(ApiClient.getPluginConfiguration(pluginId).then(function (config) {
                     config.AlwaysReplaceEpisodeNumber = container.querySelector('#AlwaysReplaceEpisodeNumber').checked;
+                    config.AlwaysUseAnitomySharp = container.querySelector('#AlwaysUseAnitomySharp').checked;
                     config.TranslationPreference = container.querySelector('#TranslationPreference').value;
                     ApiClient.updatePluginConfiguration(pluginId, config)
                         .then(Dashboard.processPluginConfigurationUpdateResult);

--- a/Jellyfin.Plugin.Bangumi/Configuration/ConfigPage.html
+++ b/Jellyfin.Plugin.Bangumi/Configuration/ConfigPage.html
@@ -126,16 +126,25 @@
                 </div>
                 <div class="checkboxContainer checkboxContainer-withDescription">
                     <label class="emby-checkbox-label">
+                        <input id="AlwaysGetTitleByAnitomySharp" is="emby-checkbox" type="checkbox"/>
+                        <span>始终使用AnitomySharp猜测动画名</span>
+                    </label>
+                </div>  
+                <div class="selectContainer">
+                    <label class="selectLabel" for="TranslationPreference">集数纠正</label>
+                </div>
+                <div class="checkboxContainer checkboxContainer-withDescription">
+                    <label class="emby-checkbox-label">
                         <input id="AlwaysReplaceEpisodeNumber" is="emby-checkbox" type="checkbox"/>
                         <span>始终根据文件名猜测集数</span>
                     </label>
                 </div>
                 <div class="checkboxContainer checkboxContainer-withDescription">
                     <label class="emby-checkbox-label">
-                        <input id="AlwaysUseAnitomySharp" is="emby-checkbox" type="checkbox"/>
-                        <span>始终使用AnitomySharp猜测动画名</span>
+                        <input id="AlwaysGetEpisodeByAnitomySharp" is="emby-checkbox" type="checkbox"/>
+                        <span>始终使用AnitomySharp猜测集数</span>
                     </label>
-                </div>
+                </div>              
                 <div>
                     <button class="raised button-submit block emby-button" is="emby-button" type="submit">
                         <span>保存</span>
@@ -182,7 +191,8 @@
             function loadConfiguration() {
                 return ApiClient.getPluginConfiguration(pluginId).then(function (config) {
                     container.querySelector('#AlwaysReplaceEpisodeNumber').checked = config.AlwaysReplaceEpisodeNumber;
-                    container.querySelector('#AlwaysUseAnitomySharp').checked = config.AlwaysUseAnitomySharp;
+                    container.querySelector('#AlwaysGetTitleByAnitomySharp').checked = config.AlwaysGetTitleByAnitomySharp;
+                    container.querySelector('#AlwaysGetEpisodeByAnitomySharp').checked = config.AlwaysGetEpisodeByAnitomySharp;
                     container.querySelector('#TranslationPreference').value = config.TranslationPreference;
                 });
             }
@@ -190,7 +200,8 @@
             function saveConfiguration() {
                 return wrapLoading(ApiClient.getPluginConfiguration(pluginId).then(function (config) {
                     config.AlwaysReplaceEpisodeNumber = container.querySelector('#AlwaysReplaceEpisodeNumber').checked;
-                    config.AlwaysUseAnitomySharp = container.querySelector('#AlwaysUseAnitomySharp').checked;
+                    config.AlwaysGetTitleByAnitomySharp = container.querySelector('#AlwaysGetTitleByAnitomySharp').checked;
+                    config.AlwaysGetEpisodeByAnitomySharp = container.querySelector('#AlwaysGetEpisodeByAnitomySharp').checked;
                     config.TranslationPreference = container.querySelector('#TranslationPreference').value;
                     ApiClient.updatePluginConfiguration(pluginId, config)
                         .then(Dashboard.processPluginConfigurationUpdateResult);

--- a/Jellyfin.Plugin.Bangumi/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Bangumi/Configuration/PluginConfiguration.cs
@@ -13,9 +13,12 @@ public class PluginConfiguration : BasePluginConfiguration
     public PluginConfiguration()
     {
         TranslationPreference = TranslationPreferenceType.Chinese;
+        AlwaysUseAnitomySharp = false;
     }
 
     public TranslationPreferenceType TranslationPreference { get; set; }
 
     public bool AlwaysReplaceEpisodeNumber { get; set; }
+
+    public bool AlwaysUseAnitomySharp { get; set; }
 }

--- a/Jellyfin.Plugin.Bangumi/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Bangumi/Configuration/PluginConfiguration.cs
@@ -13,12 +13,15 @@ public class PluginConfiguration : BasePluginConfiguration
     public PluginConfiguration()
     {
         TranslationPreference = TranslationPreferenceType.Chinese;
-        AlwaysUseAnitomySharp = false;
+        AlwaysGetTitleByAnitomySharp = false;
+        AlwaysGetEpisodeByAnitomySharp = false;
     }
 
     public TranslationPreferenceType TranslationPreference { get; set; }
 
     public bool AlwaysReplaceEpisodeNumber { get; set; }
 
-    public bool AlwaysUseAnitomySharp { get; set; }
+    public bool AlwaysGetTitleByAnitomySharp { get; set; }
+
+    public bool AlwaysGetEpisodeByAnitomySharp { get; set; }
 }

--- a/Jellyfin.Plugin.Bangumi/Jellyfin.Plugin.Bangumi.csproj
+++ b/Jellyfin.Plugin.Bangumi/Jellyfin.Plugin.Bangumi.csproj
@@ -15,6 +15,7 @@
         <PackageReference Include="Microsoft.Extensions.Http" IncludeAssets="compile" Version="6.0.0"/>
         <PackageReference Include="Fastenshtein" Version="1.0.0.8"/>
         <PackageReference Include="Microsoft.AspNetCore.Mvc" IncludeAssets="compile" Version="2.2.0"/>
+        <PackageReference Include="AnitomySharp" Version="0.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Jellyfin.Plugin.Bangumi/Providers/EpisodeProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/EpisodeProvider.cs
@@ -13,6 +13,7 @@ using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Providers;
 using Microsoft.Extensions.Logging;
 using Episode = MediaBrowser.Controller.Entities.TV.Episode;
+using Jellyfin.Plugin.Bangumi.Utils;
 
 namespace Jellyfin.Plugin.Bangumi.Providers;
 
@@ -196,6 +197,11 @@ public class EpisodeProvider : IRemoteMetadataProvider<Episode, EpisodeInfo>, IH
         var tempName = fileName;
         var episodeIndex = current ?? 0;
         var episodeIndexFromFilename = episodeIndex;
+
+        // 临时测试，待改造 #TODO
+        if(_plugin.Configuration.AlwaysGetEpisodeByAnitomySharp){
+            return double.Parse(AnitomyHelper.ExtractEpisodeNumber(fileName));
+        }
 
         foreach (var regex in NonEpisodeFileNameRegex)
         {

--- a/Jellyfin.Plugin.Bangumi/Providers/MovieProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/MovieProvider.cs
@@ -8,6 +8,7 @@ using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
 using Microsoft.Extensions.Logging;
+using Jellyfin.Plugin.Bangumi.Utils;
 
 namespace Jellyfin.Plugin.Bangumi.Providers;
 
@@ -37,8 +38,19 @@ public class MovieProvider : IRemoteMetadataProvider<Movie, MovieInfo>, IHasOrde
         var subjectId = info.ProviderIds.GetOrDefault(Constants.ProviderName);
         if (string.IsNullOrEmpty(subjectId))
         {
-            _log.LogInformation("Searching {Name} in bgm.tv", info.Name);
-            var searchResult = await _api.SearchSubject(info.Name, token);
+            var searchName = BangumiHelper.NameHelper(info.Name, _plugin);
+            _log.LogInformation("Searching {Name} in bgm.tv", searchName);
+            var searchResult = await _api.SearchSubject(searchName, token);
+            if (searchResult.Count > 0)
+                subjectId = $"{searchResult[0].Id}";
+        }
+
+        // try search OriginalTitle
+        if (string.IsNullOrEmpty(subjectId) && info.OriginalTitle != null && !String.Equals(info.OriginalTitle, info.Name, StringComparison.Ordinal))
+        {
+            var searchName = BangumiHelper.NameHelper(info.OriginalTitle, _plugin);
+            _log.LogInformation("Searching {Name} in bgm.tv", searchName);
+            var searchResult = await _api.SearchSubject(searchName, token);
             if (searchResult.Count > 0)
                 subjectId = $"{searchResult[0].Id}";
         }

--- a/Jellyfin.Plugin.Bangumi/Utils/Anitomy.cs
+++ b/Jellyfin.Plugin.Bangumi/Utils/Anitomy.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using AnitomySharp;
+
+namespace Jellyfin.Plugin.Bangumi.Utils
+{
+    public class AnitomyHelper
+    {
+        public static List<Element> ElementsOutput(string path)
+        {
+            return new List<Element>(AnitomySharp.AnitomySharp.Parse(path));
+        }
+        public static String ExtractAnimeTitle(string path)
+        {
+            var elements = AnitomySharp.AnitomySharp.Parse(path);
+            return elements.FirstOrDefault(p => p.Category == Element.ElementCategory.ElementAnimeTitle).Value;
+        }
+        public static String ExtractEpisodeTitle(string path)
+        {
+            var elements = AnitomySharp.AnitomySharp.Parse(path);
+            return elements.FirstOrDefault(p => p.Category == Element.ElementCategory.ElementEpisodeTitle).Value;
+        }
+        public static String ExtractEpisodeNumber(string path)
+        {
+            var elements = AnitomySharp.AnitomySharp.Parse(path);
+            return elements.FirstOrDefault(p => p.Category == Element.ElementCategory.ElementEpisodeNumber).Value;
+        }
+        public static String ExtractSeasonNumber(string path)
+        {
+            var elements = AnitomySharp.AnitomySharp.Parse(path);
+            return elements.FirstOrDefault(p => p.Category == Element.ElementCategory.ElementAnimeSeason).Value;
+        }
+    }
+}

--- a/Jellyfin.Plugin.Bangumi/Utils/BangumiHelper.cs
+++ b/Jellyfin.Plugin.Bangumi/Utils/BangumiHelper.cs
@@ -6,7 +6,7 @@ namespace Jellyfin.Plugin.Bangumi.Utils
     {
         public static String NameHelper(String searchName, Plugin plugin){
 
-            if (plugin.Configuration.AlwaysUseAnitomySharp){
+            if (plugin.Configuration.AlwaysGetTitleByAnitomySharp){
                 searchName = AnitomyHelper.ExtractAnimeTitle(searchName);
             }
 

--- a/Jellyfin.Plugin.Bangumi/Utils/BangumiHelper.cs
+++ b/Jellyfin.Plugin.Bangumi/Utils/BangumiHelper.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Jellyfin.Plugin.Bangumi.Utils
+{
+    public class BangumiHelper
+    {
+        public static String NameHelper(String searchName, Plugin plugin){
+
+            if (plugin.Configuration.AlwaysUseAnitomySharp){
+                searchName = AnitomyHelper.ExtractAnimeTitle(searchName);
+            }
+
+            return searchName;
+        }
+
+    }
+}


### PR DESCRIPTION
## 使用AnitomySharp猜测动画名

在不修改番剧文件夹名称的基础上，使用[Anitomy](https://github.com/erengy/anitomy)获取正确的动画名。

在anilist插件上测试过了，效果不错，不知道大家有没有这个需求

### PR特性

- 增加使用AnitomySharp猜测动画名的选项
- 在info.Name搜索不到时尝试使用info.OriginalTitle搜索

### 已知缺陷

- AnitomySharp自身解析规则并不是十全十美
- 如果文件名为罗马音，则存还在以下问题
  - bangumi部分动画不存在罗马音，无法匹配
  - 因为是罗马音与动画名（中文/原名）进行比较，所以bangumi搜索结果排序不正确

### AnitomySharp版本

测试使用的是本人维护的AnitomySharp，对应版本[0.2.0](https://github.com/chu-shen/AnitomySharp/releases/tag/0.2.0)
