### PR TITLE
fix title search logic

### DIFF
--- a/Jellyfin.Plugin.Bangumi/BangumiApi.cs
+++ b/Jellyfin.Plugin.Bangumi/BangumiApi.cs
@@ -36,9 +36,17 @@ public class BangumiApi
     public async Task<List<Subject>> SearchSubject(string keyword, CancellationToken token)
     {
         var jsonString = await SendRequest($"https://api.bgm.tv/search/subject/{Uri.EscapeDataString(keyword)}?type=2", token);
-        var searchResult = JsonSerializer.Deserialize<SearchResult<Subject>>(jsonString, _options);
-        var list = searchResult?.List ?? new List<Subject>();
-        return Subject.SortBySimilarity(list, keyword);
+        try
+        {
+            var searchResult = JsonSerializer.Deserialize<SearchResult<Subject>>(jsonString, _options);
+            var list = searchResult?.List ?? new List<Subject>();
+            return Subject.SortBySimilarity(list, keyword);
+        }
+        catch (JsonException)
+        {
+            // 404 Not Found Anime
+            return new List<Subject>();
+        }
     }
 
     public async Task<Subject?> GetSubject(int id, CancellationToken token)

--- a/Jellyfin.Plugin.Bangumi/Providers/MovieProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/MovieProvider.cs
@@ -41,19 +41,7 @@ public class MovieProvider : IRemoteMetadataProvider<Movie, MovieInfo>, IHasOrde
         var result = new MetadataResult<Movie> { ResultLanguage = Constants.Language };
 
         var subjectId = info.ProviderIds.GetOrDefault(Constants.ProviderName);
-        
-        if (string.IsNullOrEmpty(subjectId) && Configuration.AlwaysGetTitleByAnitomySharp)
-        {
-            var searchName = Anitomy.ExtractAnimeTitle(baseName) ?? info.Name;
-            _log.LogInformation("Searching {Name} in bgm.tv", searchName);
-            // 不保证使用非原名或中文进行查询时返回正确结果
-            var searchResult = await _api.SearchSubject(searchName, token);
-            if (info.Year != null)
-                searchResult = searchResult.FindAll(x => x.ProductionYear == null || x.ProductionYear == info.Year.ToString());
-            if (searchResult.Count > 0)
-                subjectId = $"{searchResult[0].Id}";
-        }
-        
+
         if (string.IsNullOrEmpty(subjectId))
         {
             var searchName = info.Name;
@@ -75,7 +63,19 @@ public class MovieProvider : IRemoteMetadataProvider<Movie, MovieInfo>, IHasOrde
             if (searchResult.Count > 0)
                 subjectId = $"{searchResult[0].Id}";
         }
-
+        
+        if (string.IsNullOrEmpty(subjectId) && Configuration.AlwaysGetTitleByAnitomySharp)
+        {
+            var searchName = Anitomy.ExtractAnimeTitle(baseName) ?? info.Name;
+            _log.LogInformation("Searching {Name} in bgm.tv", searchName);
+            // 不保证使用非原名或中文进行查询时返回正确结果
+            var searchResult = await _api.SearchSubject(searchName, token);
+            if (info.Year != null)
+                searchResult = searchResult.FindAll(x => x.ProductionYear == null || x.ProductionYear == info.Year.ToString());
+            if (searchResult.Count > 0)
+                subjectId = $"{searchResult[0].Id}";
+        }
+        
         if (string.IsNullOrEmpty(subjectId))
             return result;
 

--- a/Jellyfin.Plugin.Bangumi/Providers/MovieProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/MovieProvider.cs
@@ -41,25 +41,35 @@ public class MovieProvider : IRemoteMetadataProvider<Movie, MovieInfo>, IHasOrde
         var result = new MetadataResult<Movie> { ResultLanguage = Constants.Language };
 
         var subjectId = info.ProviderIds.GetOrDefault(Constants.ProviderName);
+        
+        if (string.IsNullOrEmpty(subjectId) && Configuration.AlwaysGetTitleByAnitomySharp)
+        {
+            var searchName = Anitomy.ExtractAnimeTitle(baseName) ?? info.Name;
+            _log.LogInformation("Searching {Name} in bgm.tv", searchName);
+            // 不保证使用非原名或中文进行查询时返回正确结果
+            var searchResult = await _api.SearchSubject(searchName, token);
+            if (info.Year != null)
+                searchResult = searchResult.FindAll(x => x.ProductionYear == null || x.ProductionYear == info.Year.ToString());
+            if (searchResult.Count > 0)
+                subjectId = $"{searchResult[0].Id}";
+        }
+        
         if (string.IsNullOrEmpty(subjectId))
         {
-            var searchName = Configuration.AlwaysGetTitleByAnitomySharp ? Anitomy.ExtractAnimeTitle(baseName) ?? info.Name : info.Name;
+            var searchName = info.Name;
             _log.LogInformation("Searching {Name} in bgm.tv", searchName);
             var searchResult = await _api.SearchSubject(searchName, token);
-            searchResult = Subject.SortBySimilarity(searchResult, searchName);
             if (info.Year != null)
                 searchResult = searchResult.FindAll(x => x.ProductionYear == null || x.ProductionYear == info.Year.ToString());
             if (searchResult.Count > 0)
                 subjectId = $"{searchResult[0].Id}";
         }
 
-        // try search OriginalTitle
         if (string.IsNullOrEmpty(subjectId) && info.OriginalTitle != null && !string.Equals(info.OriginalTitle, info.Name, StringComparison.Ordinal))
         {
-            var searchName = Configuration.AlwaysGetTitleByAnitomySharp ? Anitomy.ExtractAnimeTitle(baseName) ?? info.OriginalTitle : info.OriginalTitle;
+            var searchName = info.OriginalTitle;
             _log.LogInformation("Searching {Name} in bgm.tv", searchName);
             var searchResult = await _api.SearchSubject(searchName, token);
-            searchResult = Subject.SortBySimilarity(searchResult, searchName);
             if (info.Year != null)
                 searchResult = searchResult.FindAll(x => x.ProductionYear == null || x.ProductionYear == info.Year.ToString());
             if (searchResult.Count > 0)

--- a/Jellyfin.Plugin.Bangumi/Providers/SeriesProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/SeriesProvider.cs
@@ -40,19 +40,7 @@ public class SeriesProvider : IRemoteMetadataProvider<Series, SeriesInfo>, IHasO
         var result = new MetadataResult<Series> { ResultLanguage = Constants.Language };
 
         var subjectId = info.ProviderIds.GetOrDefault(Constants.ProviderName);
-        
-        if (string.IsNullOrEmpty(subjectId) && Configuration.AlwaysGetTitleByAnitomySharp)
-        {
-            var searchName = Anitomy.ExtractAnimeTitle(baseName) ?? info.Name;
-            _log.LogInformation("Searching {Name} in bgm.tv", searchName);
-            // 不保证使用非原名或中文进行查询时返回正确结果
-            var searchResult = await _api.SearchSubject(searchName, token);
-            if (info.Year != null)
-                searchResult = searchResult.FindAll(x => x.ProductionYear == null || x.ProductionYear == info.Year.ToString());
-            if (searchResult.Count > 0)
-                subjectId = $"{searchResult[0].Id}";
-        }
-        
+
         if (string.IsNullOrEmpty(subjectId))
         {
             var searchName = info.Name;
@@ -74,7 +62,19 @@ public class SeriesProvider : IRemoteMetadataProvider<Series, SeriesInfo>, IHasO
             if (searchResult.Count > 0)
                 subjectId = $"{searchResult[0].Id}";
         }
-
+        
+        if (string.IsNullOrEmpty(subjectId) && Configuration.AlwaysGetTitleByAnitomySharp)
+        {
+            var searchName = Anitomy.ExtractAnimeTitle(baseName) ?? info.Name;
+            _log.LogInformation("Searching {Name} in bgm.tv", searchName);
+            // 不保证使用非原名或中文进行查询时返回正确结果
+            var searchResult = await _api.SearchSubject(searchName, token);
+            if (info.Year != null)
+                searchResult = searchResult.FindAll(x => x.ProductionYear == null || x.ProductionYear == info.Year.ToString());
+            if (searchResult.Count > 0)
+                subjectId = $"{searchResult[0].Id}";
+        }
+        
         if (string.IsNullOrEmpty(subjectId))
             return result;
 


### PR DESCRIPTION
之前的逻辑存在问题，导致开启“使用 AnitomySharp 猜测动画名”后，一直使用从Path提取的名称进行查询

修正后的查询顺序：name -> origintitle -> 提取Path的动画名（如果开启）

| 类型   | 来源        | 生成方式 | 是否规范 |
| ------ | ----------- | -------- | -------- |
| 原标题 | OriginTitle | 插件生成 | 规范     |
| 标题   | Name        | 插件生成 | 规范     |
| 标题   | Path        | 文件路径 | 不规范   |
