### PR TITLE
fix: no airdate in search api response

### DIFF
--- a/Jellyfin.Plugin.Bangumi.Test/Series.cs
+++ b/Jellyfin.Plugin.Bangumi.Test/Series.cs
@@ -40,6 +40,24 @@ public class Series
     }
 
     [TestMethod]
+    public async Task GetByNameAndAirDate()
+    {
+        var result = await _provider.GetMetadata(new SeriesInfo
+        {
+            Name = "からかい上手の高木さん",
+            Year = 2022,
+        }, _token);
+        Assert.AreEqual(result.Item.ProviderIds[Constants.ProviderName], "347887");
+
+        result = await _provider.GetMetadata(new SeriesInfo
+        {
+            Name = "からかい上手の高木さん",
+            Year = 2018,
+        }, _token);
+        Assert.AreEqual(result.Item.ProviderIds[Constants.ProviderName], "219200");
+    }
+
+    [TestMethod]
     public async Task GetById()
     {
         var result = await _provider.GetMetadata(new SeriesInfo

--- a/Jellyfin.Plugin.Bangumi/BangumiApi.cs
+++ b/Jellyfin.Plugin.Bangumi/BangumiApi.cs
@@ -35,7 +35,7 @@ public class BangumiApi
 
     public async Task<List<Subject>> SearchSubject(string keyword, CancellationToken token)
     {
-        var jsonString = await SendRequest($"https://api.bgm.tv/search/subject/{Uri.EscapeDataString(keyword)}?type=2", token);
+        var jsonString = await SendRequest($"https://api.bgm.tv/search/subject/{Uri.EscapeDataString(keyword)}?type=2&responseGroup=large", token);
         try
         {
             var searchResult = JsonSerializer.Deserialize<SearchResult<Subject>>(jsonString, _options);

--- a/Jellyfin.Plugin.Bangumi/Model/Subject.cs
+++ b/Jellyfin.Plugin.Bangumi/Model/Subject.cs
@@ -20,7 +20,13 @@ public class Subject
     public string? Summary { get; set; }
 
     [JsonPropertyName("date")]
-    public string? AirDate { get; set; }
+    public string? Date { get; set; }
+
+    [JsonPropertyName("air_date")]
+    public string? Date2 { get; set; }
+
+    [JsonIgnore]
+    public string? AirDate => Date ?? Date2;
 
     [JsonIgnore]
     public string? ProductionYear => AirDate?[..4];


### PR DESCRIPTION
根据 [Bangumi API](https://bangumi.github.io/api/#/%E6%90%9C%E7%B4%A2/searchSubjectByKeywords) 定义，responseGroup 的默认值是 `small`，但 `small` 并不会返回 `air_date` 字段，因此造成 #30 的问题。即不能通过放送时间去分不同季度。