### PR TITLE
feat: support parsing bangumi id from path attribute

### DIFF
--- a/Jellyfin.Plugin.Bangumi.Test/Series.cs
+++ b/Jellyfin.Plugin.Bangumi.Test/Series.cs
@@ -40,6 +40,17 @@ public class Series
     }
 
     [TestMethod]
+    public async Task GetByAttribute()
+    {
+        var result = await _provider.GetMetadata(new SeriesInfo
+        {
+            Name = "ホワイトアルバム2",
+            Path = FakePath.Create("ホワイトアルバム2[bangumi-69496]")
+        }, _token);
+        AssertSeries(result);
+    }
+
+    [TestMethod]
     public async Task GetByNameAndAirDate()
     {
         var result = await _provider.GetMetadata(new SeriesInfo

--- a/Jellyfin.Plugin.Bangumi/Extensions.cs
+++ b/Jellyfin.Plugin.Bangumi/Extensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Jellyfin.Plugin.Bangumi;
 
@@ -7,5 +8,61 @@ public static class Extensions
     public static T? GetOrDefault<TKey, T>(this IDictionary<TKey, T> dict, TKey key)
     {
         return dict.TryGetValue(key, out var value) ? value : default;
+    }
+}
+
+/// <summary>
+/// Class providing extension methods for working with paths.
+/// From: https://github.com/jellyfin/jellyfin/blob/master/Emby.Server.Implementations/Library/PathExtensions.cs#L10
+/// </summary>
+public static class PathExtensions
+{
+    /// <summary>
+    /// Gets the attribute value.
+    /// </summary>
+    /// <param name="str">The STR.</param>
+    /// <param name="attribute">The attrib.</param>
+    /// <returns>System.String.</returns>
+    /// <exception cref="ArgumentException"><paramref name="str" /> or <paramref name="attribute" /> is empty.</exception>
+    public static string? GetAttributeValue(this string? str, string attribute)
+    {
+        if (string.IsNullOrEmpty(str))
+        {
+            return null;
+        }
+        if (str.Length == 0)
+        {
+            throw new ArgumentException("String can't be empty.", nameof(str));
+        }
+
+        if (attribute.Length == 0)
+        {
+            throw new ArgumentException("String can't be empty.", nameof(attribute));
+        }
+
+        var attributeIndex = str.IndexOf(attribute, StringComparison.OrdinalIgnoreCase);
+
+        // Must be at least 3 characters after the attribute =, ], any character.
+        var maxIndex = str.Length - attribute.Length - 3;
+        while (attributeIndex > -1 && attributeIndex < maxIndex)
+        {
+            var attributeEnd = attributeIndex + attribute.Length;
+            if (attributeIndex > 0
+                && str[attributeIndex - 1] == '['
+                && (str[attributeEnd] == '=' || str[attributeEnd] == '-'))
+            {
+                var closingIndex = str[attributeEnd..].IndexOf(']');
+                // Must be at least 1 character before the closing bracket.
+                if (closingIndex > 1)
+                {
+                    return str[(attributeEnd + 1)..(attributeEnd + closingIndex)].Trim().ToString();
+                }
+            }
+
+            str = str[attributeEnd..];
+            attributeIndex = str.IndexOf(attribute, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return null;
     }
 }

--- a/Jellyfin.Plugin.Bangumi/Providers/SeriesProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/SeriesProvider.cs
@@ -37,6 +37,12 @@ public class SeriesProvider : IRemoteMetadataProvider<Series, SeriesInfo>, IHasO
         var baseName = Path.GetFileName(info.Path);
         var result = new MetadataResult<Series> { ResultLanguage = Constants.Language };
 
+        var bangumiId = baseName.GetAttributeValue("bangumi");
+        if (!string.IsNullOrEmpty(bangumiId) && !info.HasProviderId(Constants.ProviderName))
+        {
+            info.SetProviderId(Constants.ProviderName, bangumiId);
+        }
+
         if (int.TryParse(info.ProviderIds.GetOrDefault(Constants.ProviderName), out var subjectId))
         {
         }


### PR DESCRIPTION
Support parsing bangumi id from folder name like:
`ホワイトアルバム2[bangumi-69496]`
`ホワイトアルバム2[bangumi=69496]`

ref: tips on https://jellyfin.org/docs/general/server/media/shows