### PR TITLE
更换章节收藏信息API

### DIFF
--- a/Jellyfin.Plugin.Bangumi/BangumiApi.cs
+++ b/Jellyfin.Plugin.Bangumi/BangumiApi.cs
@@ -204,10 +204,9 @@ public class BangumiApi
 
     public async Task UpdateEpisodeStatus(string accessToken, int subjectId, int episodeId, EpisodeCollectionType status, CancellationToken token)
     {
-        var request = new HttpRequestMessage(HttpMethod.Patch, $"https://api.bgm.tv/v0/users/-/collections/{subjectId}/episodes");
-        request.Content = new JsonContent(new EpisodesCollectionInfo
+        var request = new HttpRequestMessage(HttpMethod.Put, $"https://api.bgm.tv/v0/users/-/collections/-/episodes/{episodeId}");
+        request.Content = new JsonContent(new EpisodeCollectionInfo
         {
-            EpisodeIdList = new List<int> { episodeId },
             Type = status
         });
         await SendRequest(request, accessToken, token);


### PR DESCRIPTION
#64 原来使用的api有问题，太久没修不知道什么情况，换成新的[更新单个ep状态api](https://bangumi.github.io/api/#/%E6%94%B6%E8%97%8F/putUserEpisodeCollection)