### PR TITLE
fix: 重复标记已观看时，同步api检查状态

### DIFF
--- a/Jellyfin.Plugin.Bangumi/BangumiApi.cs
+++ b/Jellyfin.Plugin.Bangumi/BangumiApi.cs
@@ -202,6 +202,11 @@ public class BangumiApi
         await SendRequest(request, accessToken, token);
     }
 
+    public async Task<EpisodeCollectionInfo?> GetEpisodeStatus(string accessToken, int episodeId, CancellationToken token)
+    {
+        return await SendRequest<EpisodeCollectionInfo>($"https://api.bgm.tv/v0/users/-/collections/-/episodes/{episodeId}", accessToken, token);
+    }
+    
     public async Task UpdateEpisodeStatus(string accessToken, int subjectId, int episodeId, EpisodeCollectionType status, CancellationToken token)
     {
         var request = new HttpRequestMessage(HttpMethod.Put, $"https://api.bgm.tv/v0/users/-/collections/-/episodes/{episodeId}");


### PR DESCRIPTION
- 手动标记未观看时，传入played值应为false
- 已观看的章节重新触发时，检查API状态为watched再跳过