### PR TITLE
fix: empty exception message

### DIFF
--- a/Jellyfin.Plugin.Bangumi/Model/ServerException.cs
+++ b/Jellyfin.Plugin.Bangumi/Model/ServerException.cs
@@ -46,7 +46,7 @@ public class ServerException : Exception
     public class ErrorDetail
     {
         [JsonPropertyName("error")]
-        public string Message { get; set; } = "";
+        public string? Message { get; set; }
 
         [JsonPropertyName("path")]
         public string RequestPath { get; set; } = "";


### PR DESCRIPTION
#74 

https://github.com/kookxiang/jellyfin-plugin-bangumi/blob/a0097430ed3575dab4e05ab2a129f58199a1bded/Jellyfin.Plugin.Bangumi/Model/ServerException.cs#L22-L24

result.Error.Message默认值为空字符串，导致exception内容为空