### PR TITLE
feat: 忽略小于五分钟的文件

### DIFF
--- a/Jellyfin.Plugin.Bangumi/Configuration/ConfigPage.html
+++ b/Jellyfin.Plugin.Bangumi/Configuration/ConfigPage.html
@@ -194,6 +194,14 @@
                         </label>
                     </div>
                 </div>
+                <div class="selectContainer">
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label class="emby-checkbox-label">
+                            <input id="IgnoreLessThanFiveMinutes" is="emby-checkbox" type="checkbox"/>
+                            <span>屏蔽时长小于五分钟的文件</span>
+                        </label>
+                    </div>
+                </div>
                 <div class="verticalSection verticalSection">
                     <div class="sectionTitleContainer flex align-items-center">
                         <h2 class="sectionTitle">AnitomySharp</h2>

--- a/Jellyfin.Plugin.Bangumi/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Bangumi/Configuration/PluginConfiguration.cs
@@ -31,4 +31,6 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool AlwaysGetEpisodeByAnitomySharp { get; set; }
 
     public bool UseTestingSearchApi { get; set; }
+    
+    public bool IgnoreLessThanFiveMinutes { get; set; }
 }

--- a/Jellyfin.Plugin.Bangumi/Jellyfin.Plugin.Bangumi.csproj
+++ b/Jellyfin.Plugin.Bangumi/Jellyfin.Plugin.Bangumi.csproj
@@ -10,18 +10,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AnitomySharp" Version="0.2.0"/>
-        <PackageReference Include="Fastenshtein" Version="1.0.0.8"/>
-        <PackageReference Include="Jellyfin.Controller" IncludeAssets="compile" Version="10.8.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.Authorization" IncludeAssets="compile" Version="6.0.12"/>
+        <PackageReference Include="AnitomySharp" Version="0.2.0" />
+        <PackageReference Include="Fastenshtein" Version="1.0.0.8" />
+        <PackageReference Include="Jellyfin.Controller" IncludeAssets="compile" Version="10.8.0" />
+        <PackageReference Include="Lib.Harmony" Version="2.2.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Authorization" IncludeAssets="compile" Version="6.0.12" />
     </ItemGroup>
 
     <ItemGroup>
-        <None Remove="Configuration\configPage.html"/>
-        <EmbeddedResource Include="Configuration\ConfigPage.html"/>
+        <None Remove="Configuration\configPage.html" />
+        <EmbeddedResource Include="Configuration\ConfigPage.html" />
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="Jellyfin.Plugin.Bangumi.Test"/>
+        <InternalsVisibleTo Include="Jellyfin.Plugin.Bangumi.Test" />
     </ItemGroup>
 </Project>

--- a/Jellyfin.Plugin.Bangumi/Patch/MediaInfoPatch.cs
+++ b/Jellyfin.Plugin.Bangumi/Patch/MediaInfoPatch.cs
@@ -1,0 +1,21 @@
+﻿using HarmonyLib;
+using MediaBrowser.Model.MediaInfo;
+
+namespace Jellyfin.Plugin.Bangumi.Patch;
+
+[HarmonyPatch("MediaBrowser.MediaEncoding.Probing.ProbeResultNormalizer", "GetMediaInfo")]
+public class MediaInfoPatch
+{
+    internal static void Postfix(bool isAudio, string path, MediaInfo __result)
+    {
+        if (isAudio) return;
+        if (__result.RunTimeTicks is not > 0) return;
+        if (Plugin.Instance!.MediaTicks.TryGetValue(path, out var ticks) && ticks == __result.RunTimeTicks.Value)
+            return;
+        if (ticks == 0)
+            Plugin.Instance.MediaTicks.Add(path, __result.RunTimeTicks.Value);
+        else
+            Plugin.Instance.MediaTicks[path] = __result.RunTimeTicks.Value;
+        Plugin.Instance.SaveCache();
+    }
+}

--- a/Jellyfin.Plugin.Bangumi/Plugin.cs
+++ b/Jellyfin.Plugin.Bangumi/Plugin.cs
@@ -1,20 +1,28 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using HarmonyLib;
 using Jellyfin.Plugin.Bangumi.Configuration;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
+using Newtonsoft.Json;
 
 namespace Jellyfin.Plugin.Bangumi;
 
 public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 {
     public static Plugin? Instance;
+    
+    public Dictionary<string, long> MediaTicks = new();
 
     public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer) : base(applicationPaths, xmlSerializer)
     {
         Instance = this;
+        LoadCache();
+        var harmony = new Harmony("jellyfin.plugin.bangumi");
+        harmony.PatchAll();
     }
 
     /// <inheritdoc />
@@ -37,5 +45,21 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
                 EmbeddedResourcePath = $"{GetType().Namespace}.Configuration.ConfigPage.html"
             }
         };
+    }
+
+    public void LoadCache()
+    {
+        var ticksPath = Path.Combine(ApplicationPaths.CachePath, "bangumi", "ticks.json");
+        if (File.Exists(ticksPath))
+            MediaTicks = JsonConvert.DeserializeObject<Dictionary<string, long>>(File.ReadAllText(ticksPath));
+    }
+    
+    public void SaveCache()
+    {
+        var json = JsonConvert.SerializeObject(MediaTicks);
+        var path = Path.Combine(ApplicationPaths.CachePath, "bangumi");
+        if (!Directory.Exists(path))
+            Directory.CreateDirectory(path);
+        File.WriteAllText(Path.Combine(path, "ticks.json"), json);
     }
 }

--- a/Jellyfin.Plugin.Bangumi/Rule/IgnoreRule.cs
+++ b/Jellyfin.Plugin.Bangumi/Rule/IgnoreRule.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Resolvers;
+using MediaBrowser.Model.IO;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Bangumi.Rule;
+
+public class IgnoreRule : IResolverIgnoreRule
+{
+    private readonly ILogger<IgnoreRule> _logger;
+
+    public IgnoreRule(ILogger<IgnoreRule> logger)
+    {
+        _logger = logger;
+    }
+    
+    public bool ShouldIgnore(FileSystemMetadata fileInfo, BaseItem parent)
+    {
+        if (!Plugin.Instance!.Configuration.IgnoreLessThanFiveMinutes) return false;
+        if (!Plugin.Instance.MediaTicks.TryGetValue(fileInfo.FullName, out var ticks))
+        {
+            _logger.LogDebug($"processing file {fileInfo.FullName} error: unknown ticks");
+            return false;
+        }
+
+        var span = TimeSpan.FromTicks(ticks);
+        if (span.TotalMinutes < 5)
+        {
+            _logger.LogInformation($"Ignore file {fileInfo.FullName}. because duration {span.TotalMinutes} min < 5 min");
+            return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
https://github.com/kookxiang/jellyfin-plugin-bangumi/issues/33#issuecomment-1422664564

因为我也比较需要, 所以用一种比较魔法的方式实现了这个功能. (jellyfin 的api文档也太少了, 我实在找不到在 `IgnoreRule` 获取文件时长的方法, 只能用这种比较魔法的方式实现)
缺点是需要刷新两次媒体库才会生效.
