### PR TITLE
feat: 搜索结果排序时将考虑别名

### DIFF
--- a/Jellyfin.Plugin.Bangumi/Providers/SeriesProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/SeriesProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
@@ -68,6 +68,21 @@ public class SeriesProvider : IRemoteMetadataProvider<Series, SeriesInfo>, IHasO
                 searchResult = searchResult.FindAll(x => x.ProductionYear == animeYear);
             if (searchResult.Count > 0)
             {
+                if (searchResult.Count > 1)
+                {
+                    var subjectWithInfobox = new List<Subject>();
+                    for (int i = 0; i < Math.Min(3, searchResult.Count); i++)
+                    {
+                        var ss = await _api.GetSubject(searchResult[i].Id, token);
+                        if (ss != null)
+                        {
+                            _log.LogDebug("sort subject: {on} with infobox",ss.OriginalName);
+                            subjectWithInfobox.Add(ss);
+                        }
+                    }
+                    searchResult = Subject.SortBySimilarity(subjectWithInfobox, searchName);
+                }
+
                 subjectId = searchResult[0].Id;
                 _log.LogDebug("Use subject id: {id}", subjectId);
             }


### PR DESCRIPTION
如果使用罗马音进行搜索排序，修改前只使用中日文进行计算，导致错误匹配。修改后则能使用别名中的罗马音

e.g.
- Watashi ni Tenshi ga Maiorita!
- https://bgm.tv/subject/249637
- https://bgm.tv/subject/320493

糊了一版出来，看看该怎么弄比较好