### PR TITLE
feat: traversal searching for next season

### DIFF
--- a/Jellyfin.Plugin.Bangumi.Test/Season.cs
+++ b/Jellyfin.Plugin.Bangumi.Test/Season.cs
@@ -42,7 +42,10 @@ public class Season
     {
         var subject = await _api.SearchNextSubject(135275, _token);
         Assert.AreEqual(174043, subject?.Id, "can guess next season by subject id");
-
+        
+        subject = await _api.SearchNextSubject(152091, _token);
+        Assert.AreEqual(283643, subject?.Id, "Can guess next TV season with BFS");
+        
         subject = await _api.SearchNextSubject(174043, _token);
         Assert.AreNotEqual(220631, subject?.Id, "should skip movie");
         Assert.AreEqual(342667, subject?.Id, "can guess next season by subject id");

--- a/Jellyfin.Plugin.Bangumi.Test/Util/ServiceLocator.cs
+++ b/Jellyfin.Plugin.Bangumi.Test/Util/ServiceLocator.cs
@@ -38,6 +38,7 @@ public class ServiceLocator
 
         var plugin = GetService<Bangumi.Plugin>();
         plugin.Configuration.TranslationPreference = TranslationPreferenceType.Original;
+        plugin.Configuration.SeasonGuessMaxSearchCount = 10;
     }
 
     public static T GetService<T>()

--- a/Jellyfin.Plugin.Bangumi/Configuration/ConfigPage.html
+++ b/Jellyfin.Plugin.Bangumi/Configuration/ConfigPage.html
@@ -150,6 +150,18 @@
                         <option value="60000">1 分钟</option>
                     </select>
                 </div>
+                <div class="selectContainer">
+                    <label class="selectLabel" for="SeasonGuessMaxSearchCount">季度搜索最大请求数</label>
+                    <select class="emby-select-withcolor emby-select" id="SeasonGuessMaxSearchCount" is="emby-select">
+                        <option value="1">1</option>
+                        <option value="2">2</option>
+                        <option value="5">5</option>
+                        <option value="10">10</option>
+<!--                        <option value="114514">无限制</option>-->
+                    </select>
+                    <div class="fieldDescription">本插件使用遍历搜索关联条目的方式匹配TV动画季度。大部分情况下只需一次搜索即可完成，但某些条目可能需要多次搜索才能匹配到下一季。默认最多搜索两次，如果某些季度匹配错误，您可以尝试增加最大搜索次数。</div>
+                </div>
+                
                 <div class="verticalSection verticalSection">
                     <div class="sectionTitleContainer flex align-items-center">
                         <h2 class="sectionTitle">元数据</h2>

--- a/Jellyfin.Plugin.Bangumi/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Bangumi/Configuration/PluginConfiguration.cs
@@ -33,4 +33,6 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool UseTestingSearchApi { get; set; }
 
     public bool ConvertLineBreaks { get; set; } = true;
+
+    public int SeasonGuessMaxSearchCount { get; set; } = 2;
 }


### PR DESCRIPTION
京吹第三季会匹配失败，因为中间隔了好几个作品。改用BFS查找防止这种corner case。