### PR TITLE
fix: fix movie play status syncing in JF movie libraries

### DIFF
--- a/Jellyfin.Plugin.Bangumi/PlaybackScrobbler.cs
+++ b/Jellyfin.Plugin.Bangumi/PlaybackScrobbler.cs
@@ -115,7 +115,7 @@ public class PlaybackScrobbler : IHostedService
 
         if (item is Movie)
         {
-            episodeId = subjectId;
+            subjectId = (subjectId == 0) ? episodeId : subjectId;
             // jellyfin only have subject id for movie, so we need to get episode id from bangumi api
             var episodeList = await _api.GetSubjectEpisodeListWithOffset(subjectId, EpisodeType.Normal, 0, CancellationToken.None);
             if (episodeList?.Data.Count > 0)


### PR DESCRIPTION
如果library类型是Movies，播放状态同步会不工作，因为每个电影的parent是libraryRoot，id总是0。