### PR TITLE
fix error when season folder not exists

### DIFF
--- a/Jellyfin.Plugin.Bangumi/Providers/SeasonProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/SeasonProvider.cs
@@ -46,7 +46,7 @@ public class SeasonProvider : IRemoteMetadataProvider<Season, SeasonInfo>, IHasO
         };
         var localConfiguration = await LocalConfiguration.ForPath(info.Path);
 
-        var parent = _libraryManager.FindByPath(Path.GetDirectoryName(info.Path), true);
+        var seasonPath = Path.GetDirectoryName(info.Path);
 
         var subjectId = 0;
         if (localConfiguration.Id != 0)
@@ -65,7 +65,7 @@ public class SeasonProvider : IRemoteMetadataProvider<Season, SeasonInfo>, IHasO
         {
             subjectId = subjectIdFromParent;
         }
-        else if (parent is Series series)
+        else if (seasonPath is not null && _libraryManager.FindByPath(seasonPath, true) is Series series)
         {
             var previousSeason = series.Children
                 // Search "Season 2" for "Season 1" and "Season 2 Part X"  


### PR DESCRIPTION
https://github.com/kookxiang/jellyfin-plugin-bangumi/issues/126#issuecomment-2153722466

10.9.7版本中SeriesFolder/episode_file会异常：
```
[2024-07-14 15:51:20.314 +08:00] [INF] [98] MediaBrowser.Providers.TV.SeriesMetadataService: Creating Season "第 1 季" entry for "败犬女主太多了！"
[2024-07-14 15:51:20.318 +08:00] [ERR] [98] MediaBrowser.Providers.TV.SeasonMetadataService: Error in "Bangumi"
System.ArgumentNullException: Value cannot be null. (Parameter 'path')
   at System.ArgumentNullException.Throw(String paramName)
   at System.ArgumentNullException.ThrowIfNull(Object argument, String paramName)
   at System.ArgumentException.ThrowNullOrEmptyException(String argument, String paramName)
   at Emby.Server.Implementations.Library.LibraryManager.FindByPath(String path, Nullable`1 isFolder)
   at Jellyfin.Plugin.Bangumi.Providers.SeasonProvider.GetMetadata(SeasonInfo info, CancellationToken token) in /app/Jellyfin.Plugin.Bangumi/Providers/SeasonProvider.cs:line 49
   at MediaBrowser.Providers.Manager.MetadataService`2.ExecuteRemoteProviders(MetadataResult`1 temp, String logName, Boolean replaceData, TIdType id, IEnumerable`1 providers, CancellationToken cancellationToken)
```