### PR TITLE
do not use series overview when the episode overview is empty

### DIFF
--- a/Emby.Plugin.Bangumi/ExternalIdProvider/EpisodeProvider.cs
+++ b/Emby.Plugin.Bangumi/ExternalIdProvider/EpisodeProvider.cs
@@ -60,13 +60,11 @@ public class EpisodeProvider(BangumiApi api, ILogger log)
         if (series == null)
             return result;
 
-        // use title and overview from special episode subject if episode data is empty
+        // use title from special episode subject if episode data is empty
         if (string.IsNullOrEmpty(result.Item.Name))
             result.Item.Name = series.Name;
         if (string.IsNullOrEmpty(result.Item.OriginalTitle))
             result.Item.OriginalTitle = series.OriginalName;
-        if (string.IsNullOrEmpty(result.Item.Overview))
-            result.Item.Overview = series.Summary;
 
         return result;
     }

--- a/Jellyfin.Plugin.Bangumi/Providers/EpisodeProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/EpisodeProvider.cs
@@ -109,13 +109,11 @@ public partial class EpisodeProvider(BangumiApi api, ILogger<EpisodeProvider> lo
         if (series == null)
             return result;
 
-        // use title and overview from special episode subject if episode data is empty
+        // use title from special episode subject if episode data is empty
         if (string.IsNullOrEmpty(result.Item.Name))
             result.Item.Name = series.Name;
         if (string.IsNullOrEmpty(result.Item.OriginalTitle))
             result.Item.OriginalTitle = series.OriginalName;
-        if (string.IsNullOrEmpty(result.Item.Overview))
-            result.Item.Overview = series.Summary;
 
         var seasonNumber = parent is Season ? parent.IndexNumber : 1;
         if (!string.IsNullOrEmpty(episode.AirDate) && string.Compare(episode.AirDate, series.AirDate, StringComparison.Ordinal) < 0)


### PR DESCRIPTION
在ep简介为空时不应使用条目的主简介填入

这是为了解决下面的情况

| Before | After(expect) |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/0f42c4ee-ea72-49bd-9f1e-8d2637149130)| ![image](https://github.com/user-attachments/assets/526c751c-e784-4dbe-a891-e3c838758127)|

引用的EP:
[由美子編 「由美子の、ドキドキ湯上がり密着ロッカー」](https://bgm.tv/ep/566496)
[ミリエラ編「ミリエラの極秘野戦訓練」](https://bgm.tv/ep/566503)

Break:
当然这会break只有单集OVA/OAD无简介的情况，这样的break在可接受范围内