### PR TITLE
fix: characters sort by relation

### DIFF
--- a/Jellyfin.Plugin.Bangumi/BangumiApi.cs
+++ b/Jellyfin.Plugin.Bangumi/BangumiApi.cs
@@ -184,10 +184,12 @@ public partial class BangumiApi
 
     public async Task<List<PersonInfo>> GetSubjectCharacters(int id, CancellationToken token)
     {
-        var result = new List<PersonInfo>();
         var characters = await SendRequest<List<RelatedCharacter>>($"{BaseUrl}/v0/subjects/{id}/characters", token);
-        characters?.ForEach(character => result.AddRange(character.ToPersonInfos()));
-        return result;
+
+        return characters?
+        .OrderBy(c => c.Relation == "主角" ? 0 : c.Relation == "配角" ? 1 : c.Relation == "客串" ? 2 : 3)
+        .SelectMany(character => character.ToPersonInfos())
+        .ToList() ?? new List<PersonInfo>();
     }
 
     public async Task<List<RelatedPerson>?> GetSubjectPersons(int id, CancellationToken token)


### PR DESCRIPTION
演员按照：主角、配角、客串进行排序

before：第一位是客串
![chrome_ncIhfvZr87](https://github.com/user-attachments/assets/2b591b5f-df93-451e-a98d-e8417039a2ff)

after：
![chrome_CIzYvC3q9a](https://github.com/user-attachments/assets/62627024-a194-4187-a071-3a938a4a5763)

更明显的例子：zeta gundam