### PR TITLE
Feat sort by fuzzy

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,9 @@
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     </PropertyGroup>
     <ItemGroup>
-        <PackageVersion Include="AnitomySharp" Version="0.2.0" />
+        <PackageVersion Include="AnitomySharp.NET6" Version="0.5.1"/>
         <PackageVersion Include="Fastenshtein" Version="1.0.10" />
+        <PackageVersion Include="FuzzySharp" Version="2.0.2" />
         <PackageVersion Include="Jellyfin.Controller" Version="10.9.11" />
         <PackageVersion Include="MediaBrowser.Server.Core" Version="4.9.0.14-beta" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/Emby.Plugin.Bangumi/ExternalIdProvider/MovieProvider.cs
+++ b/Emby.Plugin.Bangumi/ExternalIdProvider/MovieProvider.cs
@@ -101,7 +101,6 @@ public class MovieProvider(BangumiApi api, ILogger logger)
         else if (!string.IsNullOrEmpty(searchInfo.Name))
         {
             var series = await api.SearchSubject(searchInfo.Name, token);
-            series = Subject.SortBySimilarity(series, searchInfo.Name);
             foreach (var item in series)
             {
                 var itemId = $"{item.Id}";

--- a/Emby.Plugin.Bangumi/ExternalIdProvider/SeriesProvider.cs
+++ b/Emby.Plugin.Bangumi/ExternalIdProvider/SeriesProvider.cs
@@ -105,7 +105,6 @@ public class SeriesProvider(BangumiApi api, ILogger log)
         else if (!string.IsNullOrEmpty(searchInfo.Name))
         {
             var series = await api.SearchSubject(searchInfo.Name, token);
-            series = Subject.SortBySimilarity(series, searchInfo.Name);
             foreach (var item in series)
             {
                 var itemId = $"{item.Id}";

--- a/Jellyfin.Plugin.Bangumi.Test/Series.cs
+++ b/Jellyfin.Plugin.Bangumi.Test/Series.cs
@@ -167,6 +167,14 @@ public class Series
 
         searchResults = await _api.SearchSubject("ガンダムビルドファイターズトライ", _token);
         Assert.AreEqual(searchResults.First().Id, 105875, "should return most similar item as first");
+
+        _plugin.Configuration.SortByFuzzScore = true;
+        searchResults = await _api.SearchSubject("The Adventures of Tom Sawyer", _token);
+        Assert.AreEqual(searchResults.First().Id, 23611, "should return most similar item as first");
+        // 原排序错误匹配: The Adventures of Mark Twain, id:113269
+        _plugin.Configuration.SortByFuzzScore = false;
+        searchResults = await _api.SearchSubject("The Adventures of Tom Sawyer", _token);
+        Assert.AreNotEqual(searchResults.First().Id, 23611, "should return most similar item as first");
     }
 
     [TestMethod]

--- a/Jellyfin.Plugin.Bangumi/BangumiApi.cs
+++ b/Jellyfin.Plugin.Bangumi/BangumiApi.cs
@@ -49,8 +49,8 @@ public partial class BangumiApi
                 var jsonString = await SendRequest(request, token);
 #endif
                 var searchResult = JsonSerializer.Deserialize<SearchResult<Subject>>(jsonString, Options);
-                var list = searchResult?.Data ?? new List<Subject>();
-                return Subject.SortBySimilarity(list, keyword);
+                return searchResult?.Data ?? new List<Subject>();
+                
             }
             else
             {

--- a/Jellyfin.Plugin.Bangumi/BangumiApi.cs
+++ b/Jellyfin.Plugin.Bangumi/BangumiApi.cs
@@ -59,6 +59,15 @@ public partial class BangumiApi
                     url += $"&type={(int)type}";
                 var searchResult = await SendRequest<SearchResult<Subject>>(url, token);
                 var list = searchResult?.List ?? new List<Subject>();
+
+                if (Plugin.Instance!.Configuration.SortByFuzzScore && list.Count > 2)
+                {
+                    // 仅使用前 5 个条目
+                    var tasks = list.Take(5).Select(subject => GetSubject(subject.Id, token));
+                    var subjectWithInfobox = await Task.WhenAll(tasks);
+
+                    return Subject.SortByFuzzScore(subjectWithInfobox.Where(s => s != null).Cast<Subject>().ToList(), keyword);
+                }
                 return Subject.SortBySimilarity(list, keyword);
             }
         }

--- a/Jellyfin.Plugin.Bangumi/Configuration/ConfigPage.html
+++ b/Jellyfin.Plugin.Bangumi/Configuration/ConfigPage.html
@@ -241,6 +241,13 @@
                     </label>
                     <div class="fieldDescription">注：搜索结果不一定更准确。</div>
                 </div>
+                <div class="checkboxContainer checkboxContainer-withDescription">
+                    <label class="emby-checkbox-label">
+                        <input id="SortByFuzzScore" is="emby-checkbox" type="checkbox" />
+                        <span>使用 FuzzyWuzzy 算法对匹配结果排序</span>
+                    </label>
+                    <div class="fieldDescription">排序时会加入条目别名，提高首个条目匹配率。测试接口未启用此算法</div>
+                </div>
                 <div class="verticalSection verticalSection">
                     <div class="sectionTitleContainer flex align-items-center">
                         <h2 class="sectionTitle">AnitomySharp</h2>

--- a/Jellyfin.Plugin.Bangumi/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Bangumi/Configuration/PluginConfiguration.cs
@@ -39,4 +39,6 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool ConvertLineBreaks { get; set; } = true;
 
     public int SeasonGuessMaxSearchCount { get; set; } = 2;
+
+    public bool SortByFuzzScore { get; set; } = false;
 }

--- a/Jellyfin.Plugin.Bangumi/Jellyfin.Plugin.Bangumi.csproj
+++ b/Jellyfin.Plugin.Bangumi/Jellyfin.Plugin.Bangumi.csproj
@@ -9,8 +9,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AnitomySharp" />
+        <PackageReference Include="AnitomySharp.NET6" />
         <PackageReference Include="Fastenshtein" />
+        <PackageReference Include="FuzzySharp" />
         <PackageReference Include="Jellyfin.Controller" IncludeAssets="compile" />
         <PackageReference Include="Newtonsoft.Json" IncludeAssets="compile" />
     </ItemGroup>

--- a/Jellyfin.Plugin.Bangumi/Model/InfoBox.cs
+++ b/Jellyfin.Plugin.Bangumi/Model/InfoBox.cs
@@ -18,6 +18,27 @@ public class InfoBox : List<InfoBoxItem>
             return null;
         }
     }
+
+    public string[]? GetAliasStrings(string key)
+    {
+        try
+        {
+            var element = this.FirstOrDefault(x => x.Key == key);
+
+            if (element?.Value.ValueKind == JsonValueKind.Array)
+            {
+                return element.Value.EnumerateArray()
+                .Select(x => x.GetProperty("v").GetString()!)
+                .Where(x => !string.IsNullOrWhiteSpace(x))
+                .ToArray();
+            }
+            return null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
 }
 
 public class InfoBoxItem

--- a/Jellyfin.Plugin.Bangumi/Providers/AlbumProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/AlbumProvider.cs
@@ -128,7 +128,6 @@ public class AlbumProvider(BangumiApi api, ILogger<AlbumProvider> log)
         else if (!string.IsNullOrEmpty(searchInfo.Name))
         {
             var series = await api.SearchSubject(searchInfo.Name, SubjectType.Music, token);
-            series = Subject.SortBySimilarity(series, searchInfo.Name);
             foreach (var item in series)
             {
                 var itemId = $"{item.Id}";

--- a/Jellyfin.Plugin.Bangumi/Providers/BookProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/BookProvider.cs
@@ -80,7 +80,6 @@ public class BookProvider(BangumiApi api)
         else if (!string.IsNullOrEmpty(searchInfo.Name))
         {
             var series = await api.SearchSubject(searchInfo.Name, SubjectType.Book, token);
-            series = Subject.SortBySimilarity(series, searchInfo.Name);
             foreach (var item in series)
             {
                 var itemId = $"{item.Id}";

--- a/Jellyfin.Plugin.Bangumi/Providers/MovieProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/MovieProvider.cs
@@ -129,7 +129,6 @@ public class MovieProvider(BangumiApi api, ILogger<MovieProvider> logger)
         else if (!string.IsNullOrEmpty(searchInfo.Name))
         {
             var series = await api.SearchSubject(searchInfo.Name, token);
-            series = Subject.SortBySimilarity(series, searchInfo.Name);
             foreach (var item in series)
             {
                 var itemId = $"{item.Id}";

--- a/Jellyfin.Plugin.Bangumi/Providers/SeriesProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/SeriesProvider.cs
@@ -149,7 +149,6 @@ public class SeriesProvider(BangumiApi api, ILogger<SeriesProvider> log)
         else if (!string.IsNullOrEmpty(searchInfo.Name))
         {
             var series = await api.SearchSubject(searchInfo.Name, token);
-            series = Subject.SortBySimilarity(series, searchInfo.Name);
             foreach (var item in series)
             {
                 var itemId = $"{item.Id}";


### PR DESCRIPTION
使用 FuzzyWuzzy 算法对匹配结果排序

- 添加 FuzzyWuzzy 算法配置项，排序时会利用条目的别名进行计算
- 去除重复的排序请求
- 测试接口返回的结果我认为无需进行排序
- 依赖：AnitomySharp 变更为 AnitomySharp.NET6