### PR TITLE
fix: return all subjects after sorted by fuzzy

### DIFF
--- a/Jellyfin.Plugin.Bangumi/BangumiApi.cs
+++ b/Jellyfin.Plugin.Bangumi/BangumiApi.cs
@@ -62,11 +62,13 @@ public partial class BangumiApi
 
                 if (Plugin.Instance!.Configuration.SortByFuzzScore && list.Count > 2)
                 {
-                    // 仅使用前 5 个条目
-                    var tasks = list.Take(5).Select(subject => GetSubject(subject.Id, token));
+                    // 仅使用前 5 个条目获取别名并排序
+                    var num = 5;
+                    var tasks = list.Take(num).Select(subject => GetSubject(subject.Id, token));
                     var subjectWithInfobox = await Task.WhenAll(tasks);
 
-                    return Subject.SortByFuzzScore(subjectWithInfobox.Where(s => s != null).Cast<Subject>().ToList(), keyword);
+                    var sortedSubjects = Subject.SortByFuzzScore(subjectWithInfobox.Where(s => s != null).Cast<Subject>().ToList(), keyword);
+                    return sortedSubjects.Concat(list.Skip(num)).ToList();
                 }
                 return Subject.SortBySimilarity(list, keyword);
             }


### PR DESCRIPTION
现在启用 Fuzzy 排序后会返回全部搜索结果，但仅前 5 个已排序

手动搜索场景有用