### PR TITLE
fix: More robust error message matching

### DIFF
--- a/Jellyfin.Plugin.Bangumi/PlaybackScrobbler.cs
+++ b/Jellyfin.Plugin.Bangumi/PlaybackScrobbler.cs
@@ -148,7 +148,7 @@ public class PlaybackScrobbler(IUserDataManager userDataManager, OAuthStore stor
         }
         catch (Exception e)
         {
-            if (played && e.Message == "Bad Request: you need to add subject to your collection first")
+            if (played && IsErrorFromUncollectedSubject(e))
             {
                 log.Info("report subject #{Subject} status {Status} to bangumi", subjectId, CollectionType.Watching);
                 await api.UpdateCollectionStatus(user.AccessToken, subjectId, CollectionType.Watching, CancellationToken.None);
@@ -180,4 +180,6 @@ public class PlaybackScrobbler(IUserDataManager userDataManager, OAuthStore stor
             await api.UpdateCollectionStatus(user.AccessToken, subjectId, CollectionType.Watched, CancellationToken.None);
         }
     }
+
+    internal static bool IsErrorFromUncollectedSubject(Exception e) => e.Message.Contains("need to add subject to your collection");
 }


### PR DESCRIPTION
#74 
如下，最近观看记录同步的error message matching有点问题，改了这个地方的匹配尽量规避一下。

![image](https://github.com/user-attachments/assets/b318e1fc-5c8f-44e5-8705-5f6bbfb194a9)
```log
[2025-02-24 07:22:21.322 +00:00] [INF] [35] Jellyfin.Plugin.PlaybackReporting.EventMonitorEntryPoint: Processing playback tracker : "e27b88a0d018f23c-2f0ddafa6c5f45bcaae20561d08f6488-23da926d21a1e81767c2e50a516714c9"
[2025-02-24 07:22:21.656 +00:00] [INF] [22] Jellyfin.Plugin.Bangumi.PlaybackScrobbler: report episode #1433480 status Watched to bangumi
[2025-02-24 07:22:21.860 +00:00] [ERR] [22] Jellyfin.Plugin.Bangumi.PlaybackScrobbler: report playback status failed: "System.Net.Http.HttpIOException: Bad Request: you need to add subject to your collection first (InvalidResponse)
   at Jellyfin.Plugin.Bangumi.BangumiApi.HandleHttpException(HttpResponseMessage response)
   at Jellyfin.Plugin.Bangumi.BangumiApi.SendWithOutCache(HttpRequestMessage request, String accessToken, CancellationToken token)
   at Jellyfin.Plugin.Bangumi.BangumiApi.UpdateEpisodeStatus(String accessToken, Int32 episodeId, EpisodeCollectionType status, CancellationToken token)
   at Jellyfin.Plugin.Bangumi.PlaybackScrobbler.ReportPlaybackStatus(BaseItem item, Guid userId, Boolean played)"
'''
