### PR TITLE
feat: add ui for controlling rating refresh intervals

### DIFF
--- a/Jellyfin.Plugin.Bangumi/Configuration/Main.html
+++ b/Jellyfin.Plugin.Bangumi/Configuration/Main.html
@@ -158,10 +158,21 @@
                         <option value="2">2</option>
                         <option value="5">5</option>
                         <option value="10">10</option>
-                        <!--<option value="114514">无限制</option>-->
                     </select>
                     <div class="fieldDescription">
                         本插件使用遍历搜索关联条目的方式匹配TV动画季度。大部分情况下只需一次搜索即可完成，但某些条目可能需要多次搜索才能匹配到下一季。默认最多搜索两次，如果某些季度匹配错误，您可以尝试增加最大搜索次数。
+                    </div>
+                </div>
+                <div class="selectContainer">
+                    <label class="selectLabel" for="RatingUpdateMinInterval">更新评分频率</label>
+                    <select class="emby-select-withcolor emby-select" id="RatingUpdateMinInterval" is="emby-select">
+                        <option value="3">3天</option>
+                        <option value="7">7天</option>
+                        <option value="14">14天</option>
+                        <option value="30">30天</option>
+                    </select>
+                    <div class="fieldDescription">
+                        默认不更新14天内已更新过的评分。如果评分频繁变化，可以选择更短的时间间隔以确保每次执行更新评分时都能覆盖旧的评分。
                     </div>
                 </div>
                 <div class="verticalSection">

--- a/Jellyfin.Plugin.Bangumi/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Bangumi/Configuration/PluginConfiguration.cs
@@ -45,4 +45,6 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool RefreshRatingWhenArchiveUpdate { get; set; } = false;
 
     public int DaysBeforeUsingArchiveData { get; set; } = 14;
+
+    public int RatingUpdateMinInterval { get; set; } = 14;
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dca7ad35-f260-43ea-aaac-bbb710264e21)
默认的14天内已更新过元数据的条目不更新评分可能有些太长，尤其是对于某些评分剧烈变化的新番，因此加入了更短的选项供配置。由于Jellyfin刷新元数据时[一般不会覆盖原来的评分](https://github.com/jellyfin/jellyfin/blob/32fe92d8f544d6dee1f0dfb5cccada649524084a/MediaBrowser.Providers/Manager/MetadataService.cs#L822)，因此很多时候必须依赖插件的任务来更新到最新的评分。