### PR TITLE
Fix：部分文件季号刮削错误

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <PackageVersion Include="AnitomySharp.NET6" Version="0.5.1" />
     <PackageVersion Include="Fastenshtein" Version="1.0.10" />
     <PackageVersion Include="FuzzySharp" Version="2.0.2" />
-    <PackageVersion Include="Jellyfin.Controller" Version="10.9.0" />
+    <PackageVersion Include="Jellyfin.Controller" Version="10.10.7" />
     <PackageVersion Include="MediaBrowser.Server.Core" Version="4.9.0.14-beta" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.3.1" />

--- a/Jellyfin.Plugin.Bangumi.Test/Episode.cs
+++ b/Jellyfin.Plugin.Bangumi.Test/Episode.cs
@@ -370,6 +370,18 @@ public class Episode
     }
 
     [TestMethod]
+    public async Task FixEpisodeNotFound()
+    {
+        var episodeData = await _provider.GetMetadata(new EpisodeInfo
+        {
+            Path = FakePath.CreateFile("[VCB-Studio] Princess Lover! OVA [01][Ma10p_720p][x265_ac3].mkv"),
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "8631" } }
+        },
+            _token);
+        Assert.IsNotNull(episodeData, "MetadataResult should not be null");
+    }
+
+    [TestMethod]
     public async Task SpecialEpisodeInDifferentSubject()
     {
         var episodeData = await _provider.GetMetadata(new EpisodeInfo

--- a/Jellyfin.Plugin.Bangumi.Test/Episode.cs
+++ b/Jellyfin.Plugin.Bangumi.Test/Episode.cs
@@ -1,8 +1,9 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Bangumi.Providers;
 using Jellyfin.Plugin.Bangumi.Test.Util;
+using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -13,8 +14,17 @@ public class Episode
 {
     private readonly Bangumi.Plugin _plugin = ServiceLocator.GetService<Bangumi.Plugin>();
     private readonly EpisodeProvider _provider = ServiceLocator.GetService<EpisodeProvider>();
+    private readonly ILibraryManager _libraryManager = ServiceLocator.GetService<ILibraryManager>();
 
     private readonly CancellationToken _token = new();
+
+    private void CreateSeason(string path)
+    {
+        _libraryManager.CreateItem(new MediaBrowser.Controller.Entities.TV.Season()
+        {
+            Path = FakePath.Create(path)
+        }, null);
+    }
 
     [TestMethod]
     public void ProviderInfo()
@@ -27,33 +37,33 @@ public class Episode
     public async Task EpisodeInfo()
     {
         var episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                Path = FakePath.CreateFile("White Album 2/White Album 2[01][Hi10p_1080p][BDRip][x264_2flac].mkv"),
-                ProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "259013" } },
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "69496" } }
-            },
+        {
+            Path = FakePath.CreateFile("White Album 2/White Album 2[01][Hi10p_1080p][BDRip][x264_2flac].mkv"),
+            ProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "259013" } },
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "69496" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
         Assert.AreEqual("WHITE ALBUM", episodeData.Item.Name, "should return the right episode title");
 
         episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                IndexNumber = 0,
-                Path = FakePath.CreateFile("ONE PIECE/海贼王--S21--E1023.MP4"),
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "975" } }
-            },
+        {
+            IndexNumber = 0,
+            Path = FakePath.CreateFile("ONE PIECE/海贼王--S21--E1023.MP4"),
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "975" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
         Assert.AreEqual(1023, episodeData.Item.IndexNumber, "should return the right episode number");
 
         episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                IndexNumber = 0,
-                Path = FakePath.CreateFile("ONE PIECE/海贼王--S21--E1026.MP4"),
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "975" } }
-            },
+        {
+            IndexNumber = 0,
+            Path = FakePath.CreateFile("ONE PIECE/海贼王--S21--E1026.MP4"),
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "975" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
@@ -64,21 +74,21 @@ public class Episode
     public async Task EpisodeInfoWithoutId()
     {
         var episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                Path = FakePath.CreateFile("White Album 2/White Album 2[01][Hi10p_1080p][BDRip][x264_2flac].mkv"),
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "69496" } }
-            },
+        {
+            Path = FakePath.CreateFile("White Album 2/White Album 2[01][Hi10p_1080p][BDRip][x264_2flac].mkv"),
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "69496" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
         Assert.AreEqual("WHITE ALBUM", episodeData.Item.Name, "should return the right episode title");
 
         episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                IndexNumber = 0,
-                Path = FakePath.CreateFile("[202204]辉夜大小姐想让我告白-超级浪漫-/[202204]辉夜大小姐想让我告白-超级浪漫- S3/ep01.mp4"),
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "317613" } }
-            },
+        {
+            IndexNumber = 0,
+            Path = FakePath.CreateFile("[202204]辉夜大小姐想让我告白-超级浪漫-/[202204]辉夜大小姐想让我告白-超级浪漫- S3/ep01.mp4"),
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "317613" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
@@ -89,11 +99,11 @@ public class Episode
     public async Task LargeEpisodeIndex()
     {
         var episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                Path = FakePath.CreateFile("[CONAN][999][1080P][AVC_AAC][CHS_JP](B07242C7).mp4"),
-                IndexNumber = 999,
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "899" } }
-            },
+        {
+            Path = FakePath.CreateFile("[CONAN][999][1080P][AVC_AAC][CHS_JP](B07242C7).mp4"),
+            IndexNumber = 999,
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "899" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
@@ -104,11 +114,11 @@ public class Episode
     public async Task SpecialEpisodeSupport()
     {
         var episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                Path = FakePath.CreateFile("SPY x FAMILY - 10 [WebRip 1080p HEVC-10bit AAC ASSx2].mkv"),
-                IndexNumber = 0,
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "329906" } }
-            },
+        {
+            Path = FakePath.CreateFile("SPY x FAMILY - 10 [WebRip 1080p HEVC-10bit AAC ASSx2].mkv"),
+            IndexNumber = 0,
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "329906" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
@@ -116,11 +126,11 @@ public class Episode
         Assert.AreEqual("ドッジボール大作戦", episodeData.Item.Name, "should return the right episode title");
 
         episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                Path = FakePath.CreateFile("[Sword Art Online - Alicization -War of Underworld-][00][BDRIP 1920x1080 HEVC-YUV420P10 FLAC].mkv"),
-                IndexNumber = 0,
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "279457" } }
-            },
+        {
+            Path = FakePath.CreateFile("[Sword Art Online - Alicization -War of Underworld-][00][BDRIP 1920x1080 HEVC-YUV420P10 FLAC].mkv"),
+            IndexNumber = 0,
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "279457" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
@@ -128,38 +138,53 @@ public class Episode
         Assert.AreEqual("リフレクション", episodeData.Item.Name, "should return the right episode title");
 
         episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                Path = FakePath.CreateFile("妄想学生会 OVA/[VCB-Studio] Seitokai Yakuindomo [16][Ma10p_1080p][x265_flac].mkv"),
-                IndexNumber = 0,
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "39118" } }
-            },
+        {
+            Path = FakePath.CreateFile("[VCB-Studio] Seitokai Yakuindomo [16][Ma10p_1080p][x265_flac].mkv"),
+            IndexNumber = 0,
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "39118" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
         Assert.AreNotEqual(episodeData.Item.ParentIndexNumber, 0, "should not mark folder as special");
+        Assert.AreEqual("167720", episodeData.Item.ProviderIds[Constants.ProviderName], "should return the right episode id");
+
+        CreateSeason("妄想学生会 OVA");
+        episodeData = await _provider.GetMetadata(new EpisodeInfo
+        {
+            Path = FakePath.CreateFile("妄想学生会 OVA/[VCB-Studio] Seitokai Yakuindomo [16][Ma10p_1080p][x265_flac].mkv"),
+            IndexNumber = 0,
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "39118" } }
+        },
+            _token);
+        Assert.IsNotNull(episodeData, "episode data should not be null");
+        Assert.IsNotNull(episodeData.Item, "episode data should not be null");
+        Assert.AreEqual(episodeData.Item.ParentIndexNumber, 0, "should mark folder as special");
         Assert.AreEqual("167720", episodeData.Item.ProviderIds[Constants.ProviderName], "should return the right episode id");
     }
 
     [TestMethod]
     public async Task SpecialEpisodeFromSubFolder()
     {
+        CreateSeason("とある科学の超電磁砲S/Specials");
         var episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                Path = FakePath.CreateFile("とある科学の超電磁砲S/Specials/01.mkv"),
-                IndexNumber = 0,
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "51928" } }
-            },
+        {
+            Path = FakePath.CreateFile("とある科学の超電磁砲S/Specials/01.mkv"),
+            IndexNumber = 0,
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "51928" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
         Assert.AreEqual("MMR Ⅲ 〜もっとまるっと超電磁砲Ⅲ〜", episodeData.Item.Name, "should return the right episode title");
 
+        CreateSeason("Season 1 OVA");
         episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                Path = FakePath.CreateFile("Season 1 OVA/Seitokai Yakuindomo [16][Ma10p_1080p][x265_flac].mkv"),
-                IndexNumber = 0,
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "39118" } }
-            },
+        {
+            Path = FakePath.CreateFile("Season 1 OVA/Seitokai Yakuindomo [16][Ma10p_1080p][x265_flac].mkv"),
+            IndexNumber = 0,
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "39118" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
@@ -170,12 +195,12 @@ public class Episode
     public async Task SpecialEpisodeMetadataFromSubject()
     {
         var episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                Path = FakePath.CreateFile("OVA\\Tonikaku Kawaii: Seifuku [WebRip 1080p HEVC-10bit AAC ASSx2].mkv"),
-                ParentIndexNumber = 0,
-                ProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "1143188" } },
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "301541" } }
-            },
+        {
+            Path = FakePath.CreateFile("OVA\\Tonikaku Kawaii: Seifuku [WebRip 1080p HEVC-10bit AAC ASSx2].mkv"),
+            ParentIndexNumber = 0,
+            ProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "1143188" } },
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "301541" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
@@ -187,11 +212,11 @@ public class Episode
     public async Task NonIntegerEpisodeIndexSupport()
     {
         var episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                Path = FakePath.CreateFile("Ore no Imouto ga Konna ni Kawaii Wake ga Nai - 12.5 [BD 1920x1080 x264 FLAC Sub(GB,Big5,Jap)].mkv"),
-                IndexNumber = 0,
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "5436" } }
-            },
+        {
+            Path = FakePath.CreateFile("Ore no Imouto ga Konna ni Kawaii Wake ga Nai - 12.5 [BD 1920x1080 x264 FLAC Sub(GB,Big5,Jap)].mkv"),
+            IndexNumber = 0,
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "5436" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
@@ -202,11 +227,11 @@ public class Episode
     public async Task FixEpisodeIndex()
     {
         var episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                IndexNumber = 1080,
-                Path = FakePath.CreateFile("White Album 2/White Album 2[01][Hi10p_1080p][BDRip][x264_2flac].mkv"),
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "69496" } }
-            },
+        {
+            IndexNumber = 1080,
+            Path = FakePath.CreateFile("White Album 2/White Album 2[01][Hi10p_1080p][BDRip][x264_2flac].mkv"),
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "69496" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
@@ -218,11 +243,11 @@ public class Episode
     public async Task FixEpisodeIndexWithoutCount()
     {
         var episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                IndexNumber = 1080,
-                Path = FakePath.CreateFile("Asobi Asobase/Asobi Asobase [12][Ma10p_1080p][x265_flac_aac].mkv"),
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "236020" } }
-            },
+        {
+            IndexNumber = 1080,
+            Path = FakePath.CreateFile("Asobi Asobase/Asobi Asobase [12][Ma10p_1080p][x265_flac_aac].mkv"),
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "236020" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
@@ -234,77 +259,77 @@ public class Episode
     public async Task FixEpisodeIndexWithNumberInName()
     {
         var episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                IndexNumber = 0,
-                Path = FakePath.CreateFile("Steins;Gate 0/Steins;Gate 0 [23][Ma10p_1080p][x265_flac].mkv"),
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "129807" } }
-            },
+        {
+            IndexNumber = 0,
+            Path = FakePath.CreateFile("Steins;Gate 0/Steins;Gate 0 [23][Ma10p_1080p][x265_flac].mkv"),
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "129807" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
         Assert.AreEqual(23, episodeData.Item.IndexNumber, "should fix episode index automatically");
 
         episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                IndexNumber = 0,
-                Path = FakePath.CreateFile("Log Horizon 2/Log Horizon 2 [08][Ma10p_1080p][x265_flac].mkv"),
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "100517" } }
-            },
+        {
+            IndexNumber = 0,
+            Path = FakePath.CreateFile("Log Horizon 2/Log Horizon 2 [08][Ma10p_1080p][x265_flac].mkv"),
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "100517" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
         Assert.AreEqual(8, episodeData.Item.IndexNumber, "should fix episode index automatically");
 
         episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                IndexNumber = 0,
-                Path = FakePath.CreateFile("Kanojo, Okarishimasu/Kanojo, Okarishimasu [07][Ma444-10p_1080p][x265_flac].mkv"),
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "296076" } }
-            },
+        {
+            IndexNumber = 0,
+            Path = FakePath.CreateFile("Kanojo, Okarishimasu/Kanojo, Okarishimasu [07][Ma444-10p_1080p][x265_flac].mkv"),
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "296076" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
         Assert.AreEqual(7, episodeData.Item.IndexNumber, "should fix episode index automatically");
 
         episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                IndexNumber = 0,
-                Path = FakePath.CreateFile("Kakegurui/Kakegurui 賭ケグルイ [Live Action S01] 第02話 (BDRip 1920x1080p x264 10bit AVC FLAC).mkv"),
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "230953" } }
-            },
+        {
+            IndexNumber = 0,
+            Path = FakePath.CreateFile("Kakegurui/Kakegurui 賭ケグルイ [Live Action S01] 第02話 (BDRip 1920x1080p x264 10bit AVC FLAC).mkv"),
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "230953" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
         Assert.AreEqual(2, episodeData.Item.IndexNumber, "should fix episode index automatically");
 
         episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                IndexNumber = 0,
-                Path = FakePath.CreateFile("Eighty-Six/[AI-Raws] 86 #02 スピアヘッド (BD HEVC 1920x1080 yuv444p10le FLAC)[E56E5DFE].mkv"),
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "302189" } }
-            },
+        {
+            IndexNumber = 0,
+            Path = FakePath.CreateFile("Eighty-Six/[AI-Raws] 86 #02 スピアヘッド (BD HEVC 1920x1080 yuv444p10le FLAC)[E56E5DFE].mkv"),
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "302189" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
         Assert.AreEqual(2, episodeData.Item.IndexNumber, "should fix episode index automatically");
 
         episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                IndexNumber = 0,
-                Path = FakePath.CreateFile("Eighty-Six/[AI-Raws] 86 #22 シン (BD HEVC 1920x1080 yuv444p10le FLAC)[65CA4ED3].mkv"),
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "331887" } }
-            },
+        {
+            IndexNumber = 0,
+            Path = FakePath.CreateFile("Eighty-Six/[AI-Raws] 86 #22 シン (BD HEVC 1920x1080 yuv444p10le FLAC)[65CA4ED3].mkv"),
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "331887" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
         Assert.AreEqual(22, episodeData.Item.IndexNumber, "should fix episode index automatically");
 
         episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                IndexNumber = 0,
-                Path = FakePath.CreateFile("Detective Conan/[SBSUB][CONAN][5][WEBRIP][1080P][HEVC_AAC][CHS_CHT_JP](951D8C84).mkv"),
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "899" } }
-            },
+        {
+            IndexNumber = 0,
+            Path = FakePath.CreateFile("Detective Conan/[SBSUB][CONAN][5][WEBRIP][1080P][HEVC_AAC][CHS_CHT_JP](951D8C84).mkv"),
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "899" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
@@ -315,11 +340,11 @@ public class Episode
     public async Task FixEpisodeIndexWithBracketsInName()
     {
         var episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                IndexNumber = 0,
-                Path = FakePath.CreateFile("Date A Live/Date A Live [05(BDBOX Ver.)][Hi10p_1080p][x264_flac].mkv"),
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "49131" } }
-            },
+        {
+            IndexNumber = 0,
+            Path = FakePath.CreateFile("Date A Live/Date A Live [05(BDBOX Ver.)][Hi10p_1080p][x264_flac].mkv"),
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "49131" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
@@ -330,12 +355,12 @@ public class Episode
     public async Task FixIncorrectEpisodeId()
     {
         var episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                IndexNumber = 1080,
-                Path = FakePath.CreateFile("Saki/Saki [01] [Hi10p_720p][BDRip][x264_flac].mkv"),
-                ProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "162427" } },
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "1444" } }
-            },
+        {
+            IndexNumber = 1080,
+            Path = FakePath.CreateFile("Saki/Saki [01] [Hi10p_720p][BDRip][x264_flac].mkv"),
+            ProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "162427" } },
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "1444" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
@@ -348,12 +373,12 @@ public class Episode
     public async Task SpecialEpisodeInDifferentSubject()
     {
         var episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                IndexNumber = 1080,
-                Path = FakePath.CreateFile("Yahari Ore no Seishun Lovecome wa Machigatte Iru. Zoku/Yahari Ore no Seishun Lovecome wa Machigatte Iru. Zoku [OVA][Ma10p_1080p][x265_flac].mkv"),
-                ProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "555794" } },
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "102134" } }
-            },
+        {
+            IndexNumber = 1080,
+            Path = FakePath.CreateFile("Yahari Ore no Seishun Lovecome wa Machigatte Iru. Zoku/Yahari Ore no Seishun Lovecome wa Machigatte Iru. Zoku [OVA][Ma10p_1080p][x265_flac].mkv"),
+            ProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "555794" } },
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "102134" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
@@ -381,14 +406,14 @@ public class Episode
     private async Task<int?> TestEpisodeIndex(string fileName, int previous, int? episodeId)
     {
         var episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                Path = FakePath.CreateFile($"White Album 2/{fileName}"),
-                IndexNumber = previous,
-                ProviderIds = episodeId == null
+        {
+            Path = FakePath.CreateFile($"White Album 2/{fileName}"),
+            IndexNumber = previous,
+            ProviderIds = episodeId == null
                     ? new Dictionary<string, string>()
                     : new Dictionary<string, string> { { Constants.ProviderName, $"{episodeId}" } },
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "69496" } }
-            },
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "69496" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
@@ -400,11 +425,11 @@ public class Episode
     {
         _plugin.Configuration.AlwaysGetEpisodeByAnitomySharp = true;
         var episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                IndexNumber = 0,
-                Path = FakePath.CreateFile("[VCB-Studio] BEATLESS [Ma10p_1080p]/[VCB-Studio] BEATLESS [05][Ma10p_1080p][x265_flac].mkv"),
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "227102" } }
-            },
+        {
+            IndexNumber = 0,
+            Path = FakePath.CreateFile("[VCB-Studio] BEATLESS [Ma10p_1080p]/[VCB-Studio] BEATLESS [05][Ma10p_1080p][x265_flac].mkv"),
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "227102" } }
+        },
             _token);
         _plugin.Configuration.AlwaysGetEpisodeByAnitomySharp = false;
         Assert.IsNotNull(episodeData, "episode data should not be null");
@@ -418,10 +443,10 @@ public class Episode
     {
         FakePath.CreateFile("Kimetsu no Yaiba/Season 2/bangumi.ini", "[Bangumi]\nID=350764\nOffset=26\n");
         var episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                IndexNumber = 0,
-                Path = FakePath.CreateFile("Kimetsu no Yaiba/Season 2/[BeanSub&FZSD&LoliHouse] Kimetsu no Yaiba - 27 [WebRip 1080p HEVC-10bit AAC ASSx2].mkv")
-            },
+        {
+            IndexNumber = 0,
+            Path = FakePath.CreateFile("Kimetsu no Yaiba/Season 2/[BeanSub&FZSD&LoliHouse] Kimetsu no Yaiba - 27 [WebRip 1080p HEVC-10bit AAC ASSx2].mkv")
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
@@ -430,10 +455,10 @@ public class Episode
 
         FakePath.CreateFile("Jujutsu Kaisen/Season 2/bangumi.ini", "[Bangumi]\nID=369304\nOffset=-24\n");
         episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                IndexNumber = 0,
-                Path = FakePath.CreateFile("Jujutsu Kaisen/Season 2/Jujutsu Kaisen (2020) - S02E03 - Hidden Inventory 3 [WEBRip-1080p][10bit][x265][AAC 2.0][JA]-LoliHouse.mkv")
-            },
+        {
+            IndexNumber = 0,
+            Path = FakePath.CreateFile("Jujutsu Kaisen/Season 2/Jujutsu Kaisen (2020) - S02E03 - Hidden Inventory 3 [WEBRip-1080p][10bit][x265][AAC 2.0][JA]-LoliHouse.mkv")
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
@@ -445,11 +470,11 @@ public class Episode
     public async Task GetEpisodeForSubjectWithSingleEpisode()
     {
         var episodeData = await _provider.GetMetadata(new EpisodeInfo
-            {
-                IndexNumber = 0,
-                Path = FakePath.CreateFile("やはり俺の青春ラブコメはまちがっている。完 OVA/[Nekomoe kissaten&VCB-Studio] Oregairu Kan [OVA][Ma10p_1080p][x265_flac].mp4"),
-                SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "325587" } }
-            },
+        {
+            IndexNumber = 0,
+            Path = FakePath.CreateFile("やはり俺の青春ラブコメはまちがっている。完 OVA/[Nekomoe kissaten&VCB-Studio] Oregairu Kan [OVA][Ma10p_1080p][x265_flac].mp4"),
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "325587" } }
+        },
             _token);
         Assert.IsNotNull(episodeData, "episode data should not be null");
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");

--- a/Jellyfin.Plugin.Bangumi.Test/Mock/MockedLibraryManager.cs
+++ b/Jellyfin.Plugin.Bangumi.Test/Mock/MockedLibraryManager.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Entities;
@@ -23,6 +24,8 @@ namespace Jellyfin.Plugin.Bangumi.Test.Mock;
 
 public class MockedLibraryManager : ILibraryManager
 {
+    private readonly Dictionary<string, BaseItem> _items = [];
+
     public BaseItem? ResolvePath(FileSystemMetadata fileInfo, Folder? parent = null, IDirectoryService? directoryService = null)
     {
         throw new NotImplementedException();
@@ -40,6 +43,14 @@ public class MockedLibraryManager : ILibraryManager
 
     public BaseItem? FindByPath(string path, bool? isFolder)
     {
+        path = path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+
+        if (_items.TryGetValue(path, out var item))
+        {
+            isFolder ??= false;
+            return item.IsFolder == isFolder ? item : null;
+        }
+
         return null;
     }
 
@@ -145,7 +156,8 @@ public class MockedLibraryManager : ILibraryManager
 
     public void CreateItem(BaseItem item, BaseItem? parent)
     {
-        throw new NotImplementedException();
+        item.Path = item.Path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+        _items[item.Path] = item;
     }
 
     public void CreateItems(IReadOnlyList<BaseItem> items, BaseItem? parent, CancellationToken cancellationToken)
@@ -439,6 +451,11 @@ public class MockedLibraryManager : ILibraryManager
     }
 
     public void QueueLibraryScan()
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task ValidateTopLibraryFolders(CancellationToken cancellationToken, bool removeRoot = false)
     {
         throw new NotImplementedException();
     }

--- a/Jellyfin.Plugin.Bangumi/Providers/EpisodePreRefreshProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/EpisodePreRefreshProvider.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+
+namespace Jellyfin.Plugin.Bangumi.Providers
+{
+    public class EpisodePreRefreshProvider : ICustomMetadataProvider<Episode>, IPreRefreshProvider
+    {
+        public string Name => Constants.ProviderName;
+
+        public Task<ItemUpdateType> FetchAsync(Episode item, MetadataRefreshOptions options, CancellationToken cancellationToken)
+        {
+            // 如果原ParentIndexNumber为空，jellyfin会从文件名猜测并预填充值，导致插件识别了也无法修改，因此预先清空该值
+            item.ParentIndexNumber = null;
+
+            return Task.FromResult(ItemUpdateType.None);
+        }
+    }
+}

--- a/Jellyfin.Plugin.Bangumi/Providers/EpisodeProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/EpisodeProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -88,7 +88,7 @@ public partial class EpisodeProvider(BangumiApi api, Logger<EpisodeProvider> log
         result.Item.ParentIndexNumber = info.ParentIndexNumber ?? 1;
 
         var parent = libraryManager.FindByPath(Path.GetDirectoryName(info.Path)!, true);
-        if (IsSpecial(info.Path, false) || episode.Type == EpisodeType.Special || info.ParentIndexNumber == 0)
+        if (IsSpecial(info.Path, true) || episode.Type == EpisodeType.Special || info.ParentIndexNumber == 0)
         {
             result.Item.ParentIndexNumber = 0;
         }

--- a/Jellyfin.Plugin.Bangumi/Providers/EpisodeProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/EpisodeProvider.cs
@@ -63,9 +63,19 @@ public partial class EpisodeProvider(BangumiApi api, Logger<EpisodeProvider> log
     {
         cancellationToken.ThrowIfCancellationRequested();
         var localConfiguration = await LocalConfiguration.ForPath(info.Path);
-        var episode = await GetEpisode(info, localConfiguration, cancellationToken);
+        Model.Episode? episode = null;
 
-        log.Info("metadata for {FilePath}: {EpisodeInfo}", Path.GetFileName(info.Path), episode);
+        // throw execption will cause the episode to not show up anywhere
+        try
+        {
+            episode = await GetEpisode(info, localConfiguration, cancellationToken);
+
+            log.Info("metadata for {FilePath}: {EpisodeInfo}", Path.GetFileName(info.Path), episode);
+        }
+        catch (Exception e)
+        {
+            log.Error($"metadata for {info.Path} error: {e.Message}");
+        }
 
         var result = new MetadataResult<Episode> { ResultLanguage = Constants.Language };
 

--- a/Jellyfin.Plugin.Bangumi/Providers/EpisodeProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/EpisodeProvider.cs
@@ -159,11 +159,25 @@ public partial class EpisodeProvider(BangumiApi api, Logger<EpisodeProvider> log
     [GeneratedRegex(@"[^\w]PV([^a-zA-Z]|$)")]
     private static partial Regex PreviewEpisodeFileNameRegex();
 
-    private static bool IsSpecial(string filePath, bool checkParent = true)
+    private bool IsSpecial(string filePath, bool checkParent = true)
     {
         var fileName = Path.GetFileName(filePath);
         var parentPath = Path.GetDirectoryName(filePath);
         var folderName = Path.GetFileName(parentPath);
+
+        if (checkParent)
+        {
+            if (parentPath == null)
+            {
+                checkParent = false;
+            }
+            else
+            {
+                // check if parent is a season(subfolder), otherwise it is a series(root folder), check on root folder is not needed
+                checkParent = libraryManager.FindByPath(parentPath, true) is Season;
+            }
+        }
+
         return SpecialEpisodeFileNameRegex().IsMatch(fileName) ||
                checkParent && SpecialEpisodeFileNameRegex().IsMatch(folderName ?? "");
     }

--- a/Jellyfin.Plugin.Bangumi/Providers/EpisodeProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/EpisodeProvider.cs
@@ -70,7 +70,19 @@ public partial class EpisodeProvider(BangumiApi api, Logger<EpisodeProvider> log
         var result = new MetadataResult<Episode> { ResultLanguage = Constants.Language };
 
         if (episode == null)
+        {
+            // remove season number
+            if (IsSpecial(info.Path, true))
+            {
+                result.HasMetadata = true;
+                result.Item = new Episode
+                {
+                    ParentIndexNumber = 0
+                };
+            }
+
             return result;
+        }
 
         result.Item = new Episode();
         result.HasMetadata = true;
@@ -230,7 +242,7 @@ public partial class EpisodeProvider(BangumiApi api, Logger<EpisodeProvider> log
             log.Info("episode is not belongs to series {SeriesId}, ignoring result", seriesId);
         }
 
-        SkipBangumiId:
+SkipBangumiId:
         log.Info("searching episode in series episode list");
         var episodeListData = await api.GetSubjectEpisodeList(seriesId, type, episodeIndex.Value, token);
 


### PR DESCRIPTION
- `Jellyfin.Plugin.Bangumi/Providers/EpisodePreRefreshProvider.cs`：修复季号无法应用修改的问题
- `Jellyfin.Plugin.Bangumi/Providers/EpisodeProvider.cs`：修复特典目录中的文件季号不为0问题

关联问题： #172