### PR TITLE
fix: Emby plugin support for macOS ARM and .NET 6 runtime

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,12 +7,12 @@
     <PackageVersion Include="Fastenshtein" Version="1.0.10" />
     <PackageVersion Include="FuzzySharp" Version="2.0.2" />
     <PackageVersion Include="Jellyfin.Controller" Version="10.11.0" />
-    <PackageVersion Include="MediaBrowser.Server.Core" Version="4.9.0.33-beta" />
+    <PackageVersion Include="MediaBrowser.Server.Core" Version="4.9.1.90" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.3.1" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
-    <PackageVersion Include="System.IO.Pipelines" Version="6.0.0" />
+    <PackageVersion Include="System.IO.Pipelines" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/Emby.Plugin.Bangumi/BangumiApi.Emby.cs
+++ b/Emby.Plugin.Bangumi/BangumiApi.Emby.cs
@@ -29,7 +29,7 @@ public partial class BangumiApi(IHttpClient httpClient, OAuthStore store)
         using var response = await httpClient.SendAsync(options, method);
         if (response.StatusCode >= HttpStatusCode.MovedPermanently) await HandleHttpException(response);
         using var stream = new StreamReader(response.Content);
-        return await stream.ReadToEndAsync(token);
+        return await stream.ReadToEndAsync();
     }
 
     public Task<T?> Get<T>(string url, CancellationToken token)
@@ -60,7 +60,7 @@ public partial class BangumiApi(IHttpClient httpClient, OAuthStore store)
             "POST");
         if (response.StatusCode >= HttpStatusCode.MovedPermanently) await HandleHttpException(response);
         using var stream = new StreamReader(response.Content);
-        return await stream.ReadToEndAsync(token);
+        return await stream.ReadToEndAsync();
     }
 
     public Task<T?> Post<T>(string url, HttpContent content)

--- a/Emby.Plugin.Bangumi/Emby.Plugin.Bangumi.csproj
+++ b/Emby.Plugin.Bangumi/Emby.Plugin.Bangumi.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
     <RootNamespace>Jellyfin.Plugin.Bangumi</RootNamespace>
     <DefineConstants>EMBY</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
## 問題描述
Emby 插件在mac arm上無法正常載入，日誌顯示 `System.Runtime, Version=8.0.0.0` 找不到的錯誤。這是因為 Emby Server 運行在 .NET 6 上，而插件編譯目標是 .NET 8。

## 修改內容
- 將目標框架從 `net8.0` 改為 `net6.0`
- 升級 `MediaBrowser.Server.Core` 到 `4.9.1.90`
- 升級 `System.IO.Pipelines` 到 `8.0.0`
- 修復 .NET 6 API 相容性問題（`ReadToEndAsync`、`HttpIOException`）
- 指定 C# 12.0 語言版本以支援主要建構函式

## 跨平台相容性
此修改提升了插件的相容性：

| 平台 | 修改前 | 修改後 |
|------|--------|--------|
| Windows |  僅 .NET 8 |  .NET 6/7/8 |
| Linux |  僅 .NET 8 |  .NET 6/7/8 |

**說明**：`net6.0` 編譯的 DLL 可以在 .NET 6、7、8 運行時上運行，因此此修改不會影響現有用戶，反而增加了對更多 Emby 版本的支援。

## 測試環境
- macOS ARM (Apple Silicon) - Emby Server 4.9.1.x 