### PR TITLE
修复Subject的PersonInfos或Characters拉取失败导致整个Subject的元数据拉取失败的问题

### DIFF
--- a/Emby.Plugin.Bangumi/ExternalIdProvider/MovieProvider.cs
+++ b/Emby.Plugin.Bangumi/ExternalIdProvider/MovieProvider.cs
@@ -70,9 +70,23 @@ public class MovieProvider(BangumiApi api, ILogger logger)
         if (subject.IsNSFW)
             result.Item.OfficialRating = "X";
 
-        (await api.GetSubjectPersonInfos(subject.Id, cancellationToken)).ToList().ForEach(result.AddPerson);
-        (await api.GetSubjectCharacters(subject.Id, cancellationToken)).ToList().ForEach(result.AddPerson);
+        try
+        {
+            (await api.GetSubjectPersonInfos(subject.Id, cancellationToken)).ToList().ForEach(result.AddPerson);
+        }
+        catch (Exception ex)
+        {
+            logger.Error("Failed to get person infos for subject {0} : {1}", subject.Id, ex);
+        }
 
+        try
+        {
+            (await api.GetSubjectCharacters(subject.Id, cancellationToken)).ToList().ForEach(result.AddPerson);
+        }
+        catch (Exception ex)
+        {
+            logger.Error("Failed to get person infos for subject {0} : {1}", subject.Id, ex);
+        }
         return result;
     }
 

--- a/Emby.Plugin.Bangumi/ExternalIdProvider/SeriesProvider.cs
+++ b/Emby.Plugin.Bangumi/ExternalIdProvider/SeriesProvider.cs
@@ -74,7 +74,24 @@ public class SeriesProvider(BangumiApi api, ILogger log)
         if (subject.IsNSFW)
             result.Item.OfficialRating = "X";
 
-        (await api.GetSubjectPersonInfos(subject.Id, cancellationToken)).ToList().ForEach(result.AddPerson);
+        try
+        {
+            (await api.GetSubjectPersonInfos(subject.Id, cancellationToken)).ToList().ForEach(result.AddPerson);
+        }
+        catch (Exception ex)
+        {
+            log.Error("Failed to get person infos for subject {0} : {1}", subject.Id, ex);
+        }
+
+        try
+        {
+            (await api.GetSubjectCharacters(subject.Id, cancellationToken)).ToList().ForEach(result.AddPerson);
+        }
+        catch (Exception ex)
+        {
+            log.Error("Failed to get person infos for subject {0} : {1}", subject.Id, ex);
+        }
+
         (await api.GetSubjectCharacters(subject.Id, cancellationToken)).ToList().ForEach(result.AddPerson);
 
         return result;

--- a/Jellyfin.Plugin.Bangumi/Providers/MovieProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/MovieProvider.cs
@@ -96,8 +96,23 @@ public class MovieProvider(BangumiApi api, Logger<MovieProvider> log)
         if (subject.IsNSFW)
             result.Item.OfficialRating = "X";
 
-        (await api.GetSubjectPersonInfos(subject.Id, cancellationToken)).ToList().ForEach(result.AddPerson);
-        (await api.GetSubjectCharacters(subject.Id, cancellationToken)).ToList().ForEach(result.AddPerson);
+        try
+        {
+            (await api.GetSubjectPersonInfos(subject.Id, cancellationToken)).ToList().ForEach(result.AddPerson);
+        }
+        catch (Exception ex)
+        {
+            log.Error("Failed to get person infos for subject {0} : {1}", subject.Id, ex);
+        }
+
+        try
+        {
+            (await api.GetSubjectCharacters(subject.Id, cancellationToken)).ToList().ForEach(result.AddPerson);
+        }
+        catch (Exception ex)
+        {
+            log.Error("Failed to get person infos for subject {0} : {1}", subject.Id, ex);
+        }
 
         return result;
     }

--- a/Jellyfin.Plugin.Bangumi/Providers/SeriesProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/SeriesProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -113,8 +113,23 @@ public class SeriesProvider(BangumiApi api, Logger<SeriesProvider> log)
         if (subject.IsNSFW)
             result.Item.OfficialRating = "X";
 
-        (await api.GetSubjectPersonInfos(subject.Id, cancellationToken)).ToList().ForEach(result.AddPerson);
-        (await api.GetSubjectCharacters(subject.Id, cancellationToken)).ToList().ForEach(result.AddPerson);
+        try
+        {
+            (await api.GetSubjectPersonInfos(subject.Id, cancellationToken)).ToList().ForEach(result.AddPerson);
+        }
+        catch (Exception ex)
+        {
+            log.Error("Failed to get person infos for subject {0} : {1}", subject.Id, ex);
+        }
+
+        try
+        {
+            (await api.GetSubjectCharacters(subject.Id, cancellationToken)).ToList().ForEach(result.AddPerson);
+        }
+        catch (Exception ex)
+        {
+            log.Error("Failed to get person infos for subject {0} : {1}", subject.Id, ex);
+        }
 
         return result;
     }


### PR DESCRIPTION
当前版本在拉取characters信息失败的时候会触发异常，导致整个剧集的元数据都直接失败，哪怕本身剧集的元数据能成功拉取
一般发生在里番中，如SubjectId=123789，属于离线数据包中存在元数据但是无法通过网络拉取的情况