### PR TITLE
fix: SeriesProvider and SeasonProvider in Emby not reading bangumi.ini

### DIFF
--- a/Emby.Plugin.Bangumi/ExternalIdProvider/SeasonProvider.cs
+++ b/Emby.Plugin.Bangumi/ExternalIdProvider/SeasonProvider.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Bangumi.Configuration;
+using Jellyfin.Plugin.Bangumi.Model;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Providers;
@@ -27,8 +28,14 @@ public class SeasonProvider(BangumiApi api, ILogger log)
     {
         cancellationToken.ThrowIfCancellationRequested();
         var result = new MetadataResult<Season> { ResultLanguage = Constants.Language };
+        var localConfiguration = await LocalConfiguration.ForPath(info.Path);
 
-        if (!int.TryParse(info.ProviderIds.GetOrDefault(Constants.ProviderName), out var subjectId))
+        var subjectId = 0;
+        if (localConfiguration.Id != 0)
+        {
+            subjectId = localConfiguration.Id;
+        }
+        else if (!int.TryParse(info.ProviderIds.GetOrDefault(Constants.ProviderName), out subjectId))
         {
             if (info.IndexNumber != 1 ||
                 !int.TryParse(info.SeriesProviderIds.GetOrDefault(Constants.ProviderName), out subjectId))

--- a/Emby.Plugin.Bangumi/ExternalIdProvider/SeriesProvider.cs
+++ b/Emby.Plugin.Bangumi/ExternalIdProvider/SeriesProvider.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Bangumi.Configuration;
+using Jellyfin.Plugin.Bangumi.Model;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Providers;
@@ -28,8 +29,13 @@ public class SeriesProvider(BangumiApi api, ILogger log)
     {
         cancellationToken.ThrowIfCancellationRequested();
         var result = new MetadataResult<Series> { ResultLanguage = Constants.Language };
+        var localConfiguration = await LocalConfiguration.ForPath(info.Path);
 
-        _ = int.TryParse(info.GetProviderId(Constants.ProviderName), out var subjectId);
+        int subjectId;
+        if (localConfiguration.Id != 0)
+            subjectId = localConfiguration.Id;
+        else
+            _ = int.TryParse(info.ProviderIds.GetOrDefault(Constants.ProviderName), out subjectId);
 
         if (subjectId == 0)
         {


### PR DESCRIPTION
为Emby版本的SeriesProvider和SeasonProvider添加读取bangumi.ini中配置的subjectId，从而和Jellyfin版本同步