### PR TITLE
feat: add episode season number

### DIFF
--- a/Jellyfin.Plugin.Bangumi.Test/Episode.cs
+++ b/Jellyfin.Plugin.Bangumi.Test/Episode.cs
@@ -654,4 +654,30 @@ public class Episode
         Assert.IsNotNull(episodeData.Item, "episode data should not be null");
         Assert.AreEqual("だから、思春期は終わらずに、青春は続いていく。", episodeData.Item.Name, "should return the right episode title");
     }
+
+    [TestMethod]
+    public async Task UseEpisodeSeason()
+    {
+        _plugin.Configuration.EpisodeParser = EpisodeParserType.AnitomySharp;
+
+        var filePath = FakePath.CreateFile("剑来.Sword.Of.Coming.2025.S02.2160p.WEB-DL.H265.AAC/Sword.Of.Coming.2025.S02E01.2160p.WEB-DL.H265.AAC.mp4");
+        var parentPath = Path.GetDirectoryName(filePath);
+        var parentFolder = new MediaBrowser.Controller.Entities.TV.Series
+        {
+            Path = parentPath,
+            Name = Path.GetFileName(parentPath)
+        };
+        _libraryManager.CreateItem(parentFolder, null);
+        var episodeData = await _provider.GetMetadata(new EpisodeInfo
+        {
+            Path = filePath,
+            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "520300" } }
+        },
+            _token);
+        _plugin.Configuration.EpisodeParser = EpisodeParserType.Basic;
+        Assert.IsNotNull(episodeData, "episode data should not be null");
+        Assert.IsNotNull(episodeData.Item, "episode data should not be null");
+        Assert.AreEqual(2, episodeData.Item.ParentIndexNumber, "should return the right episode season");
+    }
+
 }

--- a/Jellyfin.Plugin.Bangumi.Test/Episode.cs
+++ b/Jellyfin.Plugin.Bangumi.Test/Episode.cs
@@ -655,29 +655,4 @@ public class Episode
         Assert.AreEqual("だから、思春期は終わらずに、青春は続いていく。", episodeData.Item.Name, "should return the right episode title");
     }
 
-    [TestMethod]
-    public async Task UseEpisodeSeason()
-    {
-        _plugin.Configuration.EpisodeParser = EpisodeParserType.AnitomySharp;
-
-        var filePath = FakePath.CreateFile("剑来.Sword.Of.Coming.2025.S02.2160p.WEB-DL.H265.AAC/Sword.Of.Coming.2025.S02E01.2160p.WEB-DL.H265.AAC.mp4");
-        var parentPath = Path.GetDirectoryName(filePath);
-        var parentFolder = new MediaBrowser.Controller.Entities.TV.Series
-        {
-            Path = parentPath,
-            Name = Path.GetFileName(parentPath)
-        };
-        _libraryManager.CreateItem(parentFolder, null);
-        var episodeData = await _provider.GetMetadata(new EpisodeInfo
-        {
-            Path = filePath,
-            SeriesProviderIds = new Dictionary<string, string> { { Constants.ProviderName, "520300" } }
-        },
-            _token);
-        _plugin.Configuration.EpisodeParser = EpisodeParserType.Basic;
-        Assert.IsNotNull(episodeData, "episode data should not be null");
-        Assert.IsNotNull(episodeData.Item, "episode data should not be null");
-        Assert.AreEqual(2, episodeData.Item.ParentIndexNumber, "should return the right episode season");
-    }
-
 }

--- a/Jellyfin.Plugin.Bangumi/Model/Episode.cs
+++ b/Jellyfin.Plugin.Bangumi/Model/Episode.cs
@@ -61,4 +61,6 @@ public class Episode
     {
         return $"<Bangumi Episode #{Id}: {OriginalName}>";
     }
+
+    public int? SeasonNumber { get; set; }
 }

--- a/Jellyfin.Plugin.Bangumi/Providers/EpisodeProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/EpisodeProvider.cs
@@ -83,7 +83,8 @@ public class EpisodeProvider(BangumiApi api, Logger<EpisodeProvider> log, ILibra
             (int)episode.Order :
             (int)episode.Order + localConfiguration.Offset;
         result.Item.Overview = string.IsNullOrEmpty(episode.Description) ? null : episode.Description;
-        result.Item.ParentIndexNumber = parent is Series ? 1 : info.ParentIndexNumber ?? 1;
+
+        result.Item.ParentIndexNumber = episode.SeasonNumber ?? info.ParentIndexNumber ?? 1;
 
         if (BasicEpisodeParser.IsSpecial(info.Path, context.LibraryManager, true) || episode.Type == EpisodeType.Special || (parent is not Series && info.ParentIndexNumber == 0))
         {

--- a/Jellyfin.Plugin.Bangumi/Providers/EpisodeProvider.cs
+++ b/Jellyfin.Plugin.Bangumi/Providers/EpisodeProvider.cs
@@ -84,7 +84,7 @@ public class EpisodeProvider(BangumiApi api, Logger<EpisodeProvider> log, ILibra
             (int)episode.Order + localConfiguration.Offset;
         result.Item.Overview = string.IsNullOrEmpty(episode.Description) ? null : episode.Description;
 
-        result.Item.ParentIndexNumber = episode.SeasonNumber ?? info.ParentIndexNumber ?? 1;
+        result.Item.ParentIndexNumber = episode.SeasonNumber ?? (parent is Series ? 1 : info.ParentIndexNumber ?? 1);
 
         if (BasicEpisodeParser.IsSpecial(info.Path, context.LibraryManager, true) || episode.Type == EpisodeType.Special || (parent is not Series && info.ParentIndexNumber == 0))
         {


### PR DESCRIPTION
season number 思路来自 #209 

将从 episode 提取到的`SeasonNumber`作为初始值，相当于是多了一个季号数据的来源