### PR TITLE
[codex] Add Jellyfin SSL bypass option for issue #265

### DIFF
--- a/Jellyfin.Plugin.Bangumi/BangumiApi.Jellyfin.cs
+++ b/Jellyfin.Plugin.Bangumi/BangumiApi.Jellyfin.cs
@@ -106,7 +106,7 @@ public partial class BangumiApi(ArchiveData archive, OAuthStore store, Logger<Ba
             Proxy = !string.IsNullOrEmpty(_plugin.Configuration.ProxyServerUrl) ? new WebProxy(_plugin.Configuration.ProxyServerUrl) : HttpClient.DefaultProxy,
         };
         if (_plugin.Configuration.IgnoreSslErrors)
-            handler.ServerCertificateCustomValidationCallback = IgnoreServerCertificateErrors;
+            handler.ServerCertificateCustomValidationCallback = static (_, _, _, _) => true;
         var httpClient = new HttpClient(handler, true);
 #pragma warning restore CA2000, CA5399
         httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Jellyfin.Plugin.Bangumi", _plugin.Version.ToString()));
@@ -116,14 +116,6 @@ public partial class BangumiApi(ArchiveData archive, OAuthStore store, Logger<Ba
         return httpClient;
     }
 
-    private static bool IgnoreServerCertificateErrors(
-        HttpRequestMessage _,
-        X509Certificate2? __,
-        X509Chain? ___,
-        SslPolicyErrors ____)
-    {
-        return true;
-    }
 }
 
 public class JsonContent : StringContent

--- a/Jellyfin.Plugin.Bangumi/BangumiApi.Jellyfin.cs
+++ b/Jellyfin.Plugin.Bangumi/BangumiApi.Jellyfin.cs
@@ -3,8 +3,10 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Security;
 using System.Text;
 using System.Text.Json;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Bangumi.Archive;
@@ -103,6 +105,8 @@ public partial class BangumiApi(ArchiveData archive, OAuthStore store, Logger<Ba
             UseProxy = !string.IsNullOrEmpty(_plugin.Configuration.ProxyServerUrl),
             Proxy = !string.IsNullOrEmpty(_plugin.Configuration.ProxyServerUrl) ? new WebProxy(_plugin.Configuration.ProxyServerUrl) : HttpClient.DefaultProxy,
         };
+        if (_plugin.Configuration.IgnoreSslErrors)
+            handler.ServerCertificateCustomValidationCallback = IgnoreServerCertificateErrors;
         var httpClient = new HttpClient(handler, true);
 #pragma warning restore CA2000, CA5399
         httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Jellyfin.Plugin.Bangumi", _plugin.Version.ToString()));
@@ -110,6 +114,15 @@ public partial class BangumiApi(ArchiveData archive, OAuthStore store, Logger<Ba
             new ProductInfoHeaderValue("(https://github.com/kookxiang/jellyfin-plugin-bangumi)"));
         httpClient.Timeout = TimeSpan.FromMilliseconds(_plugin.Configuration.RequestTimeout);
         return httpClient;
+    }
+
+    private static bool IgnoreServerCertificateErrors(
+        HttpRequestMessage _,
+        X509Certificate2? __,
+        X509Chain? ___,
+        SslPolicyErrors ____)
+    {
+        return true;
     }
 }
 

--- a/Jellyfin.Plugin.Bangumi/Configuration/Main.html
+++ b/Jellyfin.Plugin.Bangumi/Configuration/Main.html
@@ -90,6 +90,13 @@
                                     </select>
                                     <div class="fieldDescription">只能缓解国内访问不稳定的情况，要确保国内能稳定访问请配置代理。</div>
                                 </div>
+                                <div class="checkboxContainer checkboxContainer-withDescription">
+                                    <label class="emby-checkbox-label">
+                                        <input id="IgnoreSslErrors" is="emby-checkbox" type="checkbox" />
+                                        <span>忽略 SSL 证书异常（仅在极端情况下启用）</span>
+                                    </label>
+                                    <div class="fieldDescription">这是不安全的兜底选项。仅在证书吊销状态或证书链异常导致无法访问 Bangumi 时临时启用，问题排除后请尽快关闭。</div>
+                                </div>
                                 <div class="selectContainer">
                                     <label class="selectLabel" for="SeasonGuessMaxSearchCount">季度搜索最大请求数</label>
                                     <select class="emby-select-withcolor emby-select" id="SeasonGuessMaxSearchCount" is="emby-select">

--- a/Jellyfin.Plugin.Bangumi/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Bangumi/Configuration/PluginConfiguration.cs
@@ -27,6 +27,8 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public string BaseServerUrl { get; set; } = "https://api.bgm.tv";
 
+    public bool IgnoreSslErrors { get; set; } = false;
+
     public bool ReportPlaybackStatusToBangumi { get; set; } = true;
 
     public bool SkipNSFWPlaybackReport { get; set; } = true;


### PR DESCRIPTION
## Summary
Adds a Jellyfin-only `IgnoreSslErrors` configuration switch, defaulting to off, so users can explicitly bypass remote SSL certificate validation when Bangumi requests fail with certificate chain errors such as `RevocationStatusUnknown`.

## Why
Issue #265 reports OAuth callback and manual access token flows failing on Jellyfin 10.11.8 because outbound HTTPS requests can fail certificate validation before the plugin reaches Bangumi.

## Changes
- add `IgnoreSslErrors` to plugin configuration with a default of `false`
- apply the setting in Jellyfin's unified `GetHttpClient()` path via `ServerCertificateCustomValidationCallback`
- expose the switch in the Jellyfin configuration page under the network section with a clear unsafe-use warning
- leave Emby UI and Emby networking behavior unchanged

## Impact
When users enable this switch, all Jellyfin-side Bangumi HTTP requests created through the shared client path will skip certificate validation, including OAuth, manual token validation, metadata, images, and archive downloads.

## Validation
- `dotnet build Jellyfin.Plugin.Bangumi/Jellyfin.Plugin.Bangumi.csproj -v minimal`

Closes #265