### PR TITLE
[codex] Add configurable Bangumi website URL

### DIFF
--- a/Emby.Plugin.Bangumi/Configuration/ConfigPage.html
+++ b/Emby.Plugin.Bangumi/Configuration/ConfigPage.html
@@ -132,6 +132,16 @@
                         <h2 class="sectionTitle">网络</h2>
                     </div>
                 </div>
+                <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="BaseServerUrl">Bangumi API 地址</label>
+                    <input class="emby-input" id="BaseServerUrl" type="url"/>
+                    <div class="fieldDescription">官方 API 部署在海外，请确保 Emby 上能够稳定访问或配置反代站点。</div>
+                </div>
+                <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="BaseWebsiteUrl">Bangumi 官网地址</label>
+                    <input class="emby-input" id="BaseWebsiteUrl" type="url"/>
+                    <div class="fieldDescription">用于 OAuth 授权、令牌刷新和外部链接。若 bgm.tv 访问不稳定，可填写兼容 Bangumi 官网路径的反代站点。</div>
+                </div>
                 <div class="selectContainer">
                     <select id="RequestTimeout" is="emby-select" label="请求超时时间">
                         <option value="5000">5 秒</option>

--- a/Emby.Plugin.Bangumi/Extension/ExternalEpisodeId.cs
+++ b/Emby.Plugin.Bangumi/Extension/ExternalEpisodeId.cs
@@ -15,7 +15,7 @@ public class ExternalEpisodeId : IExternalId, IHasWebsite
 
     public string Key => Constants.ProviderName;
 
-    public string UrlFormatString => "https://bgm.tv/ep/{0}";
+    public string UrlFormatString => $"{BangumiApi.BaseWebsiteUrl}/ep/{{0}}";
     
-    public string Website => "https://bgm.tv";
+    public string Website => BangumiApi.BaseWebsiteUrl;
 }

--- a/Emby.Plugin.Bangumi/Extension/ExternalMovieId.cs
+++ b/Emby.Plugin.Bangumi/Extension/ExternalMovieId.cs
@@ -15,7 +15,7 @@ public class ExternalMovieId : IExternalId, IHasWebsite
 
     public string Key => Constants.ProviderName;
 
-    public string UrlFormatString => "https://bgm.tv/subject/{0}";
+    public string UrlFormatString => $"{BangumiApi.BaseWebsiteUrl}/subject/{{0}}";
 
-    public string Website => "https://bgm.tv";
+    public string Website => BangumiApi.BaseWebsiteUrl;
 }

--- a/Emby.Plugin.Bangumi/Extension/ExternalPersionId.cs
+++ b/Emby.Plugin.Bangumi/Extension/ExternalPersionId.cs
@@ -15,7 +15,7 @@ public class ExternalPersonId : IExternalId, IHasWebsite
 
     public string Key => Constants.ProviderName;
 
-    public string UrlFormatString => "https://bgm.tv/person/{0}";
+    public string UrlFormatString => $"{BangumiApi.BaseWebsiteUrl}/person/{{0}}";
     
-    public string Website => "https://bgm.tv";
+    public string Website => BangumiApi.BaseWebsiteUrl;
 }

--- a/Emby.Plugin.Bangumi/Extension/ExternalSeasonId.cs
+++ b/Emby.Plugin.Bangumi/Extension/ExternalSeasonId.cs
@@ -15,7 +15,7 @@ public class ExternalSeasonId : IExternalId, IHasWebsite
 
     public string Key => Constants.ProviderName;
 
-    public string UrlFormatString => "https://bgm.tv/subject/{0}";
+    public string UrlFormatString => $"{BangumiApi.BaseWebsiteUrl}/subject/{{0}}";
     
-    public string Website => "https://bgm.tv";
+    public string Website => BangumiApi.BaseWebsiteUrl;
 }

--- a/Emby.Plugin.Bangumi/Extension/ExternalSeriesId.cs
+++ b/Emby.Plugin.Bangumi/Extension/ExternalSeriesId.cs
@@ -15,7 +15,7 @@ public class ExternalSeriesId : IExternalId, IHasWebsite
 
     public string Key => Constants.ProviderName;
 
-    public string UrlFormatString => "https://bgm.tv/subject/{0}";
+    public string UrlFormatString => $"{BangumiApi.BaseWebsiteUrl}/subject/{{0}}";
 
-    public string Website => "https://bgm.tv";
+    public string Website => BangumiApi.BaseWebsiteUrl;
 }

--- a/Emby.Plugin.Bangumi/OAuth/OAuthController.cs
+++ b/Emby.Plugin.Bangumi/OAuth/OAuthController.cs
@@ -113,7 +113,7 @@ public class OAuthController(BangumiApi api, OAuthStore store, ILogger log, ISes
     {
         _oAuthPath = $"{redirect.prefix}/Bangumi/OAuth";
         var redirectUri = Uri.EscapeDataString($"{_oAuthPath}?user={redirect.user}");
-        var url = $"https://bgm.tv/oauth/authorize?client_id={ApplicationId}&redirect_uri={redirectUri}&response_type=code";
+        var url = $"{BangumiApi.BaseWebsiteUrl}/oauth/authorize?client_id={ApplicationId}&redirect_uri={redirectUri}&response_type=code";
         Request.Response.Redirect(url);
     }
 
@@ -147,7 +147,7 @@ public class OAuthController(BangumiApi api, OAuthStore store, ILogger log, ISes
         ]);
         var options = new HttpRequestOptions
         {
-            Url = "https://bgm.tv/oauth/access_token",
+            Url = $"{BangumiApi.BaseWebsiteUrl}/oauth/access_token",
             RequestHttpContent = formData,
             ThrowOnErrorResponse = false
         };

--- a/Jellyfin.Plugin.Bangumi/BangumiApi.cs
+++ b/Jellyfin.Plugin.Bangumi/BangumiApi.cs
@@ -22,10 +22,18 @@ public partial class BangumiApi
     private const int PageSize = 50;
     private const int Offset = 20;
 
-    private static string BaseUrl =>
-        string.IsNullOrEmpty(Plugin.Instance?.Configuration?.BaseServerUrl)
-            ? "https://api.bgm.tv"
-            : Plugin.Instance!.Configuration.BaseServerUrl.TrimEnd('/');
+    internal static string BaseWebsiteUrl => NormalizeBaseUrl(
+        Plugin.Instance?.Configuration?.BaseWebsiteUrl,
+        "https://bgm.tv");
+
+    private static string BaseUrl => NormalizeBaseUrl(
+        Plugin.Instance?.Configuration?.BaseServerUrl,
+        "https://api.bgm.tv");
+
+    private static string NormalizeBaseUrl(string? url, string fallback)
+    {
+        return string.IsNullOrWhiteSpace(url) ? fallback : url.Trim().TrimEnd('/');
+    }
 
     public Task<IEnumerable<Subject>> SearchSubject(string keyword, CancellationToken token)
     {

--- a/Jellyfin.Plugin.Bangumi/Configuration/Main.html
+++ b/Jellyfin.Plugin.Bangumi/Configuration/Main.html
@@ -80,6 +80,11 @@
                                     <input class="emby-input" id="BaseServerUrl" type="url" />
                                     <div class="fieldDescription">官方 API 部署在海外，请确保 Jellyfin 上能够稳定访问或配置反代站点。</div>
                                 </div>
+                                <div class="inputContainer">
+                                    <label class="inputLabel inputLabelUnfocused" for="BaseWebsiteUrl">Bangumi 官网地址</label>
+                                    <input class="emby-input" id="BaseWebsiteUrl" type="url" />
+                                    <div class="fieldDescription">用于 OAuth 授权、令牌刷新和外部链接。若 bgm.tv 访问不稳定，可填写兼容 Bangumi 官网路径的反代站点。</div>
+                                </div>
                                 <div class="selectContainer">
                                     <label class="selectLabel" for="RequestTimeout">请求超时时间</label>
                                     <select class="emby-select-withcolor emby-select" id="RequestTimeout" is="emby-select">

--- a/Jellyfin.Plugin.Bangumi/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Bangumi/Configuration/PluginConfiguration.cs
@@ -29,6 +29,8 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public bool IgnoreSslErrors { get; set; } = false;
 
+    public string BaseWebsiteUrl { get; set; } = "https://bgm.tv";
+
     public bool ReportPlaybackStatusToBangumi { get; set; } = true;
 
     public bool SkipNSFWPlaybackReport { get; set; } = true;

--- a/Jellyfin.Plugin.Bangumi/External/ExternalUrl.cs
+++ b/Jellyfin.Plugin.Bangumi/External/ExternalUrl.cs
@@ -25,15 +25,15 @@ public class ExternalUrlProvider : IExternalUrlProvider
             case Movie:
             case Series:
             case Season:
-                yield return $"https://bgm.tv/subject/{id}";
+                yield return $"{BangumiApi.BaseWebsiteUrl}/subject/{id}";
                 break;
             case Audio:
             case Episode:
-                yield return $"https://bgm.tv/ep/{id}";
+                yield return $"{BangumiApi.BaseWebsiteUrl}/ep/{id}";
                 break;
             case Person:
             case MusicArtist:
-                yield return $"https://bgm.tv/person/{id}";
+                yield return $"{BangumiApi.BaseWebsiteUrl}/person/{id}";
                 break;
             default:
                 yield break;

--- a/Jellyfin.Plugin.Bangumi/OAuth/OAuthController.cs
+++ b/Jellyfin.Plugin.Bangumi/OAuth/OAuthController.cs
@@ -89,7 +89,7 @@ public class OAuthController(BangumiApi api, OAuthStore store, IAuthorizationCon
         _oAuthPath = $"{urlPrefix}/Plugins/Bangumi/OAuth";
         var redirectUri = Uri.EscapeDataString($"{_oAuthPath}?user={user}");
         return Task.FromResult<ActionResult>(
-            Redirect($"https://bgm.tv/oauth/authorize?client_id={ApplicationId}&redirect_uri={redirectUri}&response_type=code"));
+            Redirect($"{BangumiApi.BaseWebsiteUrl}/oauth/authorize?client_id={ApplicationId}&redirect_uri={redirectUri}&response_type=code"));
     }
 
     [HttpGet("OAuth")]
@@ -104,7 +104,7 @@ public class OAuthController(BangumiApi api, OAuthStore store, IAuthorizationCon
             new KeyValuePair<string, string>("redirect_uri", $"{urlPrefix}?user={user}")
         ]);
         using var httpClient = api.GetHttpClient();
-        var response = await httpClient.PostAsync("https://bgm.tv/oauth/access_token", formData);
+        var response = await httpClient.PostAsync($"{BangumiApi.BaseWebsiteUrl}/oauth/access_token", formData);
         var responseBody = await response.Content.ReadAsStringAsync();
         if (!response.IsSuccessStatusCode) return JsonSerializer.Deserialize<OAuthError>(responseBody, Constants.JsonSerializerOptions);
         var result = JsonSerializer.Deserialize<OAuthUser>(responseBody, Constants.JsonSerializerOptions)!;
@@ -128,7 +128,7 @@ public class OAuthController(BangumiApi api, OAuthStore store, IAuthorizationCon
             new KeyValuePair<string, string>("access_token", accessToken)
         ]);;
         using var httpClient = api.GetHttpClient();
-        var response = await httpClient.PostAsync("https://bgm.tv/oauth/token_status", formData);
+        var response = await httpClient.PostAsync($"{BangumiApi.BaseWebsiteUrl}/oauth/token_status", formData);
         var responseBody = await response.Content.ReadAsStringAsync();
         if (!response.IsSuccessStatusCode)
         {

--- a/Jellyfin.Plugin.Bangumi/OAuth/OAuthUser.extend.cs
+++ b/Jellyfin.Plugin.Bangumi/OAuth/OAuthUser.extend.cs
@@ -53,7 +53,7 @@ public partial class OAuthUser
 #if EMBY
         var options = new HttpRequestOptions
         {
-            Url = "https://bgm.tv/oauth/access_token",
+            Url = $"{BangumiApi.BaseWebsiteUrl}/oauth/access_token",
             RequestHttpContent = formData,
             ThrowOnErrorResponse = false
         };
@@ -62,7 +62,7 @@ public partial class OAuthUser
         var stream = new StreamReader(response.Content);
         var responseBody = await stream.ReadToEndAsync();
 #else
-        var response = await httpClient.PostAsync("https://bgm.tv/oauth/access_token", formData, cancellationToken);
+        var response = await httpClient.PostAsync($"{BangumiApi.BaseWebsiteUrl}/oauth/access_token", formData, cancellationToken);
         var isFailed = !response.IsSuccessStatusCode;
         var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
 #endif


### PR DESCRIPTION
## Summary

Adds a separate configurable Bangumi website URL alongside the existing Bangumi API URL.

This lets users point OAuth and website-facing requests at a reverse proxy when `bgm.tv` access is unstable, while keeping API requests controlled by the existing `BaseServerUrl` setting.

## Changes

- Add `BaseWebsiteUrl` with default `https://bgm.tv`.
- Add Jellyfin and Emby configuration inputs for the Bangumi website URL.
- Use `BaseWebsiteUrl` for OAuth authorize, access token, token status, and token refresh requests.
- Use `BaseWebsiteUrl` for Jellyfin/Emby external Bangumi links.

Fixes #269

## Validation

- `dotnet build Jellyfin.Plugin.Bangumi/Jellyfin.Plugin.Bangumi.csproj --no-restore`
- `dotnet build Emby.Plugin.Bangumi/Emby.Plugin.Bangumi.csproj --no-restore`
- `dotnet build Jellyfin.Plugin.Bangumi.Test/Jellyfin.Plugin.Bangumi.Test.csproj --no-restore`
- `git diff --check`

Note: `dotnet test` started but the test runner did not progress past discovery output in this local environment, so I validated with project builds instead.