### PR TITLE
[codex] Add private NSFW playback reporting

### DIFF
--- a/Jellyfin.Plugin.Bangumi/BangumiApi.cs
+++ b/Jellyfin.Plugin.Bangumi/BangumiApi.cs
@@ -481,9 +481,9 @@ public partial class BangumiApi
         return await Get<DataList<EpisodeCollectionInfo>>($"{BaseUrl}/v0/users/-/collections/{subjectId}/episodes?episode_type={episodeType}", accessToken, token, false);
     }
 
-    public async Task UpdateCollectionStatus(string accessToken, int subjectId, CollectionType type, CancellationToken token)
+    public async Task UpdateCollectionStatus(string accessToken, int subjectId, CollectionType type, CancellationToken token, bool isPrivate = false)
     {
-        await Post($"{BaseUrl}/v0/users/-/collections/{subjectId}", new JsonContent(new CollectionStatus { Type = type }), accessToken, token);
+        await Post($"{BaseUrl}/v0/users/-/collections/{subjectId}", new JsonContent(new CollectionStatus { Type = type, Private = isPrivate ? true : null }), accessToken, token);
     }
 
     public async Task<EpisodeCollectionInfo?> GetEpisodeStatus(string accessToken, int episodeId, CancellationToken token)

--- a/Jellyfin.Plugin.Bangumi/Configuration/Main.html
+++ b/Jellyfin.Plugin.Bangumi/Configuration/Main.html
@@ -58,12 +58,23 @@
                                         </label>
                                     </div>
                                 </div>
-                                <div class="selectContainer">
-                                    <div class="checkboxContainer checkboxContainer-withDescription">
-                                        <label class="emby-checkbox-label">
-                                            <input id="SkipNSFWPlaybackReport" is="emby-checkbox" type="checkbox" />
-                                            <span>忽略被标记为 NSFW 的内容</span>
-                                        </label>
+                                <div class="bangumi-sync-subsection">
+                                    <h3 class="bangumi-settings-subheading">NSFW 条目上报</h3>
+                                    <div class="selectContainer">
+                                        <div class="checkboxContainer checkboxContainer-withDescription">
+                                            <label class="emby-checkbox-label">
+                                                <input id="SkipNSFWPlaybackReport" is="emby-checkbox" type="checkbox" />
+                                                <span>禁用上报</span>
+                                            </label>
+                                        </div>
+                                    </div>
+                                    <div class="selectContainer" id="PrivateNSFWPlaybackReportContainer">
+                                        <div class="checkboxContainer checkboxContainer-withDescription">
+                                            <label class="emby-checkbox-label">
+                                                <input id="PrivateNSFWPlaybackReport" is="emby-checkbox" type="checkbox" />
+                                                <span>仅自己可见</span>
+                                            </label>
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/Jellyfin.Plugin.Bangumi/Configuration/Main.js
+++ b/Jellyfin.Plugin.Bangumi/Configuration/Main.js
@@ -127,7 +127,17 @@
             if (container.querySelector('#EpisodeParser')) {
                 updateEpisodeParserDisplay();
             }
+
+            updateNSFWReportDisplay();
         });
+    }
+
+    function updateNSFWReportDisplay() {
+        var skipNSFWReport = container.querySelector('#SkipNSFWPlaybackReport');
+        var privateNSFWReportContainer = container.querySelector('#PrivateNSFWPlaybackReportContainer');
+        if (!skipNSFWReport || !privateNSFWReportContainer) return;
+
+        privateNSFWReportContainer.style.display = skipNSFWReport.checked ? 'none' : '';
     }
 
     function saveConfiguration() {
@@ -175,6 +185,8 @@
         e.preventDefault();
         saveConfiguration();
     });
+
+    container.querySelector('#SkipNSFWPlaybackReport').addEventListener('change', updateNSFWReportDisplay);
 
     container.querySelector('#bangumi-oauth-btn').addEventListener('click', function (e) {
         e.preventDefault();

--- a/Jellyfin.Plugin.Bangumi/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Bangumi/Configuration/PluginConfiguration.cs
@@ -31,6 +31,8 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public bool SkipNSFWPlaybackReport { get; set; } = true;
 
+    public bool PrivateNSFWPlaybackReport { get; set; } = false;
+
     public bool ReportManualStatusChangeToBangumi { get; set; } = false;
 
     public bool TrustExistedBangumiId { get; set; } = false;

--- a/Jellyfin.Plugin.Bangumi/Configuration/Style.css
+++ b/Jellyfin.Plugin.Bangumi/Configuration/Style.css
@@ -203,6 +203,16 @@
     max-width: none;
 }
 
+.bangumi-sync-subsection {
+    margin-top: 24px;
+    padding-top: 20px;
+    border-top: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.bangumi-sync-subsection .bangumi-settings-subheading {
+    margin: 0 0 16px;
+}
+
 #bangumi-archive-container {
     margin-bottom: 24px;
 }

--- a/Jellyfin.Plugin.Bangumi/PlaybackScrobbler.cs
+++ b/Jellyfin.Plugin.Bangumi/PlaybackScrobbler.cs
@@ -94,6 +94,7 @@ public class PlaybackScrobbler(IUserDataManager userDataManager, OAuthStore stor
             return;
         }
 
+        var reportPrivate = false;
         try
         {
             if (item is Book)
@@ -119,6 +120,7 @@ public class PlaybackScrobbler(IUserDataManager userDataManager, OAuthStore stor
                     log.Info("item #{Name} marked as NSFW, skipped", item.Name);
                     return;
                 }
+                reportPrivate = subject?.IsNSFW == true && Configuration.PrivateNSFWPlaybackReport;
 
                 var episodeStatus = await api.GetEpisodeStatus(user.AccessToken, episodeId, CancellationToken.None);
                 if (episodeStatus?.Type == EpisodeCollectionType.Watched)
@@ -145,7 +147,7 @@ public class PlaybackScrobbler(IUserDataManager userDataManager, OAuthStore stor
             if (played && IsErrorFromUncollectedSubject(e))
             {
                 log.Info("report subject #{Subject} status {Status} to bangumi", subjectId, CollectionType.Watching);
-                await api.UpdateCollectionStatus(user.AccessToken, subjectId, CollectionType.Watching, CancellationToken.None);
+                await api.UpdateCollectionStatus(user.AccessToken, subjectId, CollectionType.Watching, CancellationToken.None, reportPrivate);
 
                 log.Info("report episode #{Episode} status {Status} to bangumi", episodeId, EpisodeCollectionType.Watched);
                 await api.UpdateEpisodeStatus(user.AccessToken,
@@ -171,7 +173,7 @@ public class PlaybackScrobbler(IUserDataManager userDataManager, OAuthStore stor
         if (epList is { Total: > 0 } && epList.Data.All(ep => ep.Type == EpisodeCollectionType.Watched))
         {
             log.Info("report subject #{Subject} status {Status} to bangumi", subjectId, CollectionType.Watched);
-            await api.UpdateCollectionStatus(user.AccessToken, subjectId, CollectionType.Watched, CancellationToken.None);
+            await api.UpdateCollectionStatus(user.AccessToken, subjectId, CollectionType.Watched, CancellationToken.None, reportPrivate);
         }
     }
 


### PR DESCRIPTION
Adds a Jellyfin NSFW private reporting setting, sends Private=true through UpdateCollectionStatus, and hides the private toggle when NSFW reporting is disabled. Validated with: dotnet build Jellyfin.Plugin.Bangumi/Jellyfin.Plugin.Bangumi.csproj --no-restore